### PR TITLE
Fixed issue when deleting SPAM notes.

### DIFF
--- a/assets/ap-admin.js
+++ b/assets/ap-admin.js
@@ -490,7 +490,7 @@ function ap_option_flag_note(){
 		jQuery(clone).insertBefore(this);
 	});
 	jQuery('body').delegate('.delete-flag-note', 'click', function(){
-		jQuery(this).parent().remove();
+		jQuery(this).parent().parent().parent().remove();
 	});
 }
 


### PR DESCRIPTION
The selector now runs up the parent elements until it removes the entire spam note table (instead of only a single cell).
