### PR TITLE
Fix notice

### DIFF
--- a/includes/class-form.php
+++ b/includes/class-form.php
@@ -458,7 +458,7 @@ class AnsPress_Form {
      * @since 2.0.1
      */
     private function have_error(){
-        if(isset($this->errors[$this->field['name']]))
+        if(isset($this->field['name']) && isset($this->errors[$this->field['name']]))
             return true;
 
         return false;


### PR DESCRIPTION
Hi, great plugin. I was getting this notice:

Notice: Undefined index: name in .../wp-content/plugins/anspress-question-answer/includes/class-form.php on line 459

and that is how I fixed it. Server is running with PHP 5.6.9