### PR TITLE
Fix overlap of status dropdown in question page on some themes

### DIFF
--- a/theme/default/css/main.css
+++ b/theme/default/css/main.css
@@ -1967,7 +1967,7 @@ body ul ul#ap-user-menu-link li > a .count {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   display: none;
   position: absolute;
-  right: 0;
+  left: 0;
   width: 160px;
   z-index: 99;
 }


### PR DESCRIPTION
I noticed on some themes dropdown menu is not visible because it is "too right" and connot fit the page, half of the menu is not visible.
This simple change is fixed the issue for me.
