### PR TITLE
Fixed compatibility issue with multisite subsites

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -38,7 +38,7 @@ function anspress_activate( $network_wide ) {
 
 		$charset_collate = !empty($wpdb->charset) ? "DEFAULT CHARACTER SET ".$wpdb->charset : '';
 
-		$meta_table = "CREATE TABLE IF NOT EXISTS `".$wpdb->base_prefix."ap_meta` (
+		$meta_table = "CREATE TABLE IF NOT EXISTS `".$wpdb->prefix."ap_meta` (
 				  `apmeta_id` bigint(20) NOT NULL AUTO_INCREMENT,
 				  `apmeta_userid` bigint(20) DEFAULT NULL,
 				  `apmeta_type` varchar(256) DEFAULT NULL,


### PR DESCRIPTION
The activation hook uses a database table creation script that references $wpdb->base_prefix, which on multisite is the prefix for the primary site. The rest of the code uses $wpdb->prefix, which is correct for multisite. If you install AnsPress on a multisite subsite, the table reference breaks because the table was created with the wrong prefix. This pull request fixes that problem.