### PR TITLE
Update theme.php (make html w3c compliant)

### DIFF
--- a/includes/theme.php
+++ b/includes/theme.php
@@ -393,7 +393,7 @@ function ap_icon($name, $html = false) {
 	$icon = esc_attr( $icon ); // Escape attribute.
 
 	if ( $html ) {
-		return '<i class="'.$icon.'"></i> ';
+		return '<span class="'.$icon.'"></span> ';
 	}
 
 	return $icon;


### PR DESCRIPTION
The use of <i> for icons if not W3C compliant and makes the validator fail. This can negatively affect SEO, and affect page rendering. 

It is recommended to use <span> for icons.
