### PR TITLE
Update hooks.php for better avatar

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -471,7 +471,7 @@ class AnsPress_Hooks
 	        $active_user_page   = get_query_var( 'user_page' ) ? esc_attr( get_query_var( 'user_page' ) ) : 'about';
 
 	        $o  = '<a id="ap-user-menu-anchor" class="ap-dropdown-toggle" href="#">';
-	        $o .= get_avatar( get_current_user_id(), 80 );
+	        $o .= get_avatar( get_current_user_id(), 20 );
 	        $o .= '<span class="name">'. ap_user_display_name( get_current_user_id() ) .'</span>';
 	        $o .= ap_icon( 'chevron-down', true );
 	        $o .= '</a>';


### PR DESCRIPTION
Updates the avatar size from 80px to 20px. Which is the correct size (20px is also used in the anspress css). 

When using the 80px the avatar is not correctly sized in the menu. This resolves this issue.