### PR TITLE
Made ap_get_questions overridable.

### DIFF
--- a/includes/question-loop.php
+++ b/includes/question-loop.php
@@ -126,6 +126,7 @@ if ( ! class_exists( 'Question_Query' ) ) :
 
 endif;
 
+if( !function_exists('ap_get_questions') ) {
 function ap_get_questions($args = array()) {
 
 	if ( is_front_page() ) {
@@ -158,6 +159,7 @@ function ap_get_questions($args = array()) {
 	));
 
 	return new Question_Query( $args );
+}
 }
 
 


### PR DESCRIPTION
We should be able to redefine ap_get_questions for different situations. For example, if you'd like to hide a category or a question belonging to a category based on a role, you should be able to do that without affecting the main plugin by redefining your ap_get_questions.