### PR TITLE
Improved accuracy of 'member for _'.

### DIFF
--- a/includes/users-loop.php
+++ b/includes/users-loop.php
@@ -543,6 +543,13 @@ function ap_user_get_member_for() {
 	if ( $diff->d > 0 ) {
 		$time .= sprintf( __( '%d days', 'anspress-question-answer' ), $diff->d ); }
 
+	if ($time == '') {
+		if ($diff->h > 0) {
+			$time .= sprintf( __( '%d hours', 'anspress-question-answer' ), $diff->h ); }
+		else {
+			$time .= sprintf( __( '%d minutes', 'anspress-question-answer' ), $diff->i ); }
+	}
+
 	return $time;
 }
 


### PR DESCRIPTION
The function ap_user_get_member_for() previously gave no output for users who joined today.

Changed to:
If member has been registered for over 1 hour but under 1 day, output will be "_ hours".
If a member has been registered for under 1 hour, output will be "_ minutes".