### PR TITLE
Update editor.css to keep emoji width at 1em

### DIFF
--- a/templates/css/editor.css
+++ b/templates/css/editor.css
@@ -10,6 +10,10 @@ blockquote {
 	padding-left: 10px;
 }
 
+.emoji {
+	width: 1em;
+}
+
 img {
 	height: auto;
 	max-width: 100%;


### PR DESCRIPTION
Keep emoji width at 1em when editing a question or answer. Related question at anspress.io: https://anspress.io/questions/question/the-rise-of-the-emojis/