### PR TITLE
Make reputations date accurate

### DIFF
--- a/includes/reputation.php
+++ b/includes/reputation.php
@@ -48,7 +48,7 @@ function ap_insert_reputation( $event, $ref_id, $user_id = false ) {
 	// 	return false;
 	// }
 
-	$insert = $wpdb->insert( $wpdb->ap_reputations, [ 'rep_user_id' => $user_id, 'rep_event' => sanitize_text_field( $event ), 'rep_ref_id' => $ref_id, 'rep_date' => current_time( 'mysql' ) ], [ '%d', '%s', '%d', '%s' ] ); // WPCS: db call okay.
+	$insert = $wpdb->insert( $wpdb->ap_reputations, [ 'rep_user_id' => $user_id, 'rep_event' => sanitize_text_field( $event ), 'rep_ref_id' => $ref_id, 'rep_date' => current_time( 'mysql', true ) ], [ '%d', '%s', '%d', '%s' ] ); // WPCS: db call okay.
 
 	if ( false === $insert ) {
 		return false;


### PR DESCRIPTION
As all displaying function for date/time (like ap_human_time()) consider time as UTC, recorded dates and times must be UTC, not local time...