### PR TITLE
Correcting modify_query_archive

### DIFF
--- a/addons/free/profile.php
+++ b/addons/free/profile.php
@@ -421,6 +421,9 @@ class AnsPress_Profile_Hooks {
 				status_header( 404 );
 			}
 		}
+        
+        return $posts;
+        
 	}
 
 	/**


### PR DESCRIPTION
The function doesn’t return $posts, meaning that no other plugins can
use the hook posts_pre_query