### PR TITLE
Add translation capability to the picture upload modal

### DIFF
--- a/assets/js/tinymce-plugin.js
+++ b/assets/js/tinymce-plugin.js
@@ -25,12 +25,12 @@
         });
       });
       ed.addButton('apmedia', {
-        title: 'Insert image',
+        title: ed.getLang('anspress.i18n_insert_image'),
         icon: 'image',
         onclick: function () {
           // Open window
           var win = ed.windowManager.open({
-            title: 'Insert Media (AnsPress)',
+            title: ed.getLang('anspress.i18n_insert_media'),
             resizable: true,
             scrollbars: true,
             width: 500,
@@ -46,7 +46,7 @@
                 }
               },
               {
-                text: 'Close',
+                ed.getLang('anspress.i18n_close'),
                 onclick: function () {
                   win.close();
                 }
@@ -55,8 +55,8 @@
             body: [{
                 type: 'button',
                 name: 'file-browser',
-                label: 'Select File',
-                text: 'Browse from computer',
+                label: ed.getLang('anspress.i18n_select_file'),
+                text: ed.getLang('anspress.i18n_browse_from_computer'),
                 onclick: function (e) {
                   $ta_name = jQuery(ed.getElement()).attr('id') + '-images[]';
                   var input = jQuery('<input name="'+ $ta_name +'" type="file" accept="image/*" />').hide();
@@ -80,13 +80,13 @@
               {
                 type: 'textbox',
                 name: 'file-title',
-                label: 'Image title',
+                label: ed.getLang('anspress.i18n_image_title'),
                 minWidth: 300
               },
               {
                 type: 'container',
                 name: 'image-preview',
-                label: 'Media preview',
+                label: ed.getLang('anspress.i18n_media_preview'),
               },
             ]
           });

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -82,6 +82,7 @@ class AnsPress_Hooks {
 			anspress()->add_action( 'ap_after_answer_content', 'AnsPress_Theme', 'question_attachments', 11 );
 			anspress()->add_filter( 'nav_menu_css_class', __CLASS__, 'fix_nav_current_class', 10, 2 );
 			anspress()->add_filter( 'mce_external_plugins', __CLASS__, 'mce_plugins' );
+            anspress()->add_filter( 'mce_external_languages', __CLASS__, 'mce_plugins_languages' );
 			anspress()->add_filter( 'wp_insert_post_data', __CLASS__, 'wp_insert_post_data', 1000, 2 );
 			anspress()->add_filter( 'ap_form_contents_filter', __CLASS__, 'sanitize_description' );
 			anspress()->add_filter( 'human_time_diff', __CLASS__, 'human_time_diff' );
@@ -508,6 +509,27 @@ class AnsPress_Hooks {
 		return $plugin_array;
 	}
 
+    /**
+     * Filters the translations loaded for external TinyMCE 3.x plugins.
+     *
+     * The filter takes an associative array ('plugin_name' => 'path')
+     * where 'path' is the include path to the file.
+     *
+     * The language file should follow the same format as wp_mce_translation(),
+     * and should define a variable ($strings) that holds all translated strings.
+     *
+     * @since 4.5.0
+     *
+     * @param array $translations Translations for external TinyMCE plugins.
+     */
+    
+    public static function mce_plugins_languages( $translations ) {
+        
+        $translations['anspress'] = ANSPRESS_DIR . 'includes/mce-languages.php';
+        return $translations;
+        
+    }
+    
 	/**
 	 * Filter post so that anonymous author should not be replaced
 	 * by current user approving post.

--- a/includes/mce-languages.php
+++ b/includes/mce-languages.php
@@ -1,0 +1,25 @@
+<?php # -*- coding: utf-8 -*-
+if ( ! defined( 'ABSPATH' ) )
+    exit;
+
+if ( ! class_exists( '_WP_Editors' ) )
+    require( ABSPATH . WPINC . '/class-wp-editor.php' );
+
+function get_anspress_tinymce_plugin_translations_string() {
+    $strings = array(
+        'i18n_insert_image' => __( 'Insert image', 'anspress-question-answer' ),
+        'i18n_insert_media' => __( 'Insert Media (AnsPress)', 'anspress-question-answer' ),
+        'i18n_close' => __( 'Close', 'anspress-question-answer' ),
+        'i18n_select_file' => __( 'Select File', 'anspress-question-answer' ),
+        'i18n_browse_from_computer' => __( 'Browse from computer', 'anspress-question-answer' ),
+        'i18n_image_title' => __( 'Image title', 'anspress-question-answer' ),
+        'i18n_media_preview' => __( 'Media preview', 'anspress-question-answer' ),
+                     
+    );
+    $locale = _WP_Editors::$mce_locale;
+    $translated = 'tinyMCE.addI18n("' . $locale . '.anspress", ' . json_encode( $strings ) . ");\n";
+
+     return $translated;
+}
+
+$strings = get_anspress_tinymce_plugin_translations_string();


### PR DESCRIPTION
The text strings for the TinyMCE plugin in charge of uploading pictures
is hardcoded in js and so inaccessible to translation. With this update
the strings are loaded as localisation to the TinyMCE plugin and can be
then translated. I didn’t minified any file and/or update translations.