### PR TITLE
Change rewrite rules order

### DIFF
--- a/includes/rewrite.php
+++ b/includes/rewrite.php
@@ -162,8 +162,7 @@ class AnsPress_Rewrite {
 			$ap_rules[ $r ] = $re;
 			self::$counter = 1;
 		}
-		$front = ltrim( $wp_rewrite->front, '/' );
-		$wp_rewrite->rules = ap_array_insert_after( $wp_rewrite->rules, $front . 'type/([^/]+)/?$', $ap_rules );
+		$wp_rewrite->rules = array_merge($ap_rules, $wp_rewrite->rules);
 		return $wp_rewrite->rules;
 	}
 


### PR DESCRIPTION
Rewrite rules must be ordered from the most specific to the least specific.
Rather than adding the rules at the end of the array, you must add them at the beginning. This way they will be executed before more generic rules.
Note: if somenone use ap_rewrites filter to adapt rules to Polylang with lang prefix in urls, it is mandatory to do this way...