### PR TITLE
activity feed broken for editing comment

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -461,6 +461,7 @@ class AnsPress_Hooks {
 			'q_id'   => $q_id,
 			'a_id'   => $a_id,
 			'action' => 'edit_c',
+            'c_id'   => $comment_id,
 		) );
 	}
 


### PR DESCRIPTION
the comment_id is not stocked in the activity and returned with a value
of 0. Wordpress then throw an error in the activity feed when trying to
get the comment_excerpt of a comment with ID of 0