### PR TITLE
Add singular.php as one of the default templates

### DIFF
--- a/includes/class-theme.php
+++ b/includes/class-theme.php
@@ -280,7 +280,7 @@ class AnsPress_Theme {
 	 */
 	public static function anspress_basepage_template( $template ) {
 		if ( is_anspress() ) {
-			$templates = [ 'anspress.php', 'page.php', 'index.php' ];
+			$templates = [ 'anspress.php', 'page.php', 'singular.php', 'index.php' ];
 
 			if ( is_page() ) {
 				$_post = get_queried_object();


### PR DESCRIPTION
According to https://developer.wordpress.org/themes/template-files-section/page-template-files/, singular.php is one of the default templates.