### PR TITLE
 Better textarea rendering

### DIFF
--- a/templates/scss/form.scss
+++ b/templates/scss/form.scss
@@ -29,6 +29,10 @@
 
 	textarea.ap-form-control{
 		height: auto;
+		width: 100%;
+		max-width: 100%;
+		min-width: 100%;
+		margin-bottom: 15px;
 	}
 
 	label.inline-cb{


### PR DESCRIPTION
Constraints textarea to fill 100% of the width parent, add a bottom margin like other controls.