### PR TITLE
Make the User Reputation link auto-open the BuddyPress Member Q&A Rep…

### DIFF
--- a/addons/free/reputation.php
+++ b/addons/free/reputation.php
@@ -377,7 +377,12 @@ class AnsPress_Reputation_Hooks {
 			if ( $args['html'] ) {
 				$reputation = ap_get_user_reputation_meta( $args['user_id'] );
 
-				return $name . '<a href="' . ap_user_link( $args['user_id'] ) . '?tab=reputations" class="ap-user-reputation" title="' . __( 'Reputation', 'anspress-question-answer' ) . '">' . $reputation . '</a>';
+				if( ap_is_addon_active( 'free/buddypress.php' ) && function_exists( 'bp_core_get_userlink' ) ) {
+					return $name . '<a href="' . ap_user_link( $args['user_id'] ) . 'qa/reputations" class="ap-user-reputation" title="' . __( 'Reputation', 'anspress-question-answer' ) . '">' . $reputation . '</a>';
+				}
+				else {
+					return $name . '<a href="' . ap_user_link( $args['user_id'] ) . '?tab=reputations" class="ap-user-reputation" title="' . __( 'Reputation', 'anspress-question-answer' ) . '">' . $reputation . '</a>';
+				}
 			}
 		}
 


### PR DESCRIPTION
…utations tab

`ap_user_link( $args['user_id'] ) . '?tab=reputations` does not auto-open the BuddyPress Member Q&A Reputations tab when the BuddyPress AddOn is enabled.