### PR TITLE
ap_user_can_read_comments missed the logic to allow only users with a…

### DIFF
--- a/includes/class/roles-cap.php
+++ b/includes/class/roles-cap.php
@@ -1502,8 +1502,11 @@ function ap_user_can_read_comments( $_post = null, $user_id = false ) {
 
 	$option = ap_opt( 'read_comment_per' );
 
-	if ( 'logged_in' === $option && is_user_logged_in() ) {
-		return true;
+	if( 'have_cap' === $option && get_user_by( 'ID', $user_id )->has_cap( 'ap_read_comment' ) ) {
+	    return true;
+	}
+	else if ( 'logged_in' === $option && is_user_logged_in() ) {
+	    return true;
 	} elseif ( 'anyone' === $option ) {
 		return true;
 	}


### PR DESCRIPTION
…p_read_comment capability to read comments.