### PR TITLE
newline fix in case of \r\n\r\n sequences in post content

### DIFF
--- a/lib/class-validate.php
+++ b/lib/class-validate.php
@@ -189,12 +189,13 @@ class Validate {
 
 			$new_value = preg_replace_callback( '/<pre(.*?)>(.*?)<\/pre>/imsu', [ __CLASS__, 'pre_content' ], $new_value );
 			$new_value = preg_replace_callback( '/<code.*?>(.*?)<\/code>/imsu', [ __CLASS__, 'code_content' ], $new_value );
-
+			
 			// Remove multiple new lines.
-			$new_value           = preg_replace( '/[\r\n]\s*[\r\n]/', "\n", $new_value );
+			$new_value = str_replace("\r\n", "\n", $new_value);
+			$new_value = preg_replace( '/\n\s*\n/', "\n\n", $new_value );
 
 			// Remove single white single space in line.
-			$new_value           = preg_replace( '/&nbsp;/', "\n", $new_value );
+			$new_value = preg_replace( '/&nbsp;/', "\n", $new_value );
 
 			return $new_value;
 		}


### PR DESCRIPTION
newline fix in case of \r\n\r\n sequences in post content
anspress is currently removing required newlines which leads to br tags instead of p tags
This fix handles this and keeps double newlines to get p in the output.

Can be tested the following way:
1. Create a post with newlines. 
2. The output is br tags in a p tag which is wrong. Only tripple newlines generates p tags.
3. Editing the post removes newlines and at the end you will get br tags instead of the desired p tags.
