### PR TITLE
Return true when bp_current_component returns "qa"

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -136,8 +136,7 @@ function is_anspress() {
 
 	// If BuddyPress installed.
 	if ( function_exists( 'bp_current_component' ) ) {
-		$bp_com = bp_current_component();
-		if ( 'questions' === $bp_com || 'answers' === $bp_com ) {
+		if ( in_array( bp_current_component(),  array( 'qa', 'questions', 'answers' ) ) ) {
 			$ret = true;
 		}
 	}


### PR DESCRIPTION
I am using BuddyPress 3.1.0 and Anspress 4.1.14.
Accessing Q&A tab bp_current_component returns "qa".

![image](https://user-images.githubusercontent.com/22457494/45580562-fae19f00-b868-11e8-8f58-235feb3af545.png)

![image](https://user-images.githubusercontent.com/22457494/45580595-45631b80-b869-11e8-9d80-a8835fe9fe7a.png)
