### PR TITLE
Fix for cached password missing login bug

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1309,18 +1309,7 @@ function ap_disable_question_suggestion() {
  * @since 4.0.0
  */
 function ap_post_author_pre_fetch( $ids ) {
-	$users = get_users(
-		[
-			'include' => $ids,
-			'fields'  => array( 'ID', 'user_login', 'user_nicename', 'user_email', 'display_name' ),
-		]
-	);
-
-	foreach ( (array) $users as $user ) {
-		update_user_caches( $user );
-	}
-
-	update_meta_cache( 'user', $ids );
+	cache_users($ids);
 }
 
 


### PR DESCRIPTION
Hi, when user data is cached without user_pass field, then login not work, because cant handle hash comparsion when get_user_by() so field 'user_pass' must be added to the ap_post_author_pre_fetch() function. Or why just not use build-in cache_users($ids); function?