### PR TITLE
Fix human time translation. #519

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -254,7 +254,7 @@ function ap_human_time( $time, $unix = true, $show_full_date = 604800, $format =
 		if ( $show_full_date + $time > current_time( 'timestamp', true ) ) {
 			return sprintf(
 				/* translators: %s: human-readable time difference */
-				_x( '%s ago', 'anspress-question-answer' ),
+				__( '%s ago', 'anspress-question-answer' ),
 				human_time_diff( $time, current_time( 'timestamp', true ) )
 			);
 		}

--- a/languages/anspress-question-answer.pot
+++ b/languages/anspress-question-answer.pot
@@ -4381,7 +4381,6 @@ msgstr ""
 
 #: includes/functions.php:257
 #. translators: %s: human-readable time difference
-msgctxt "anspress-question-answer"
 msgid "%s ago"
 msgstr ""
 


### PR DESCRIPTION
Fixing an issue that prevents the translation of human time string: `%s ago`. The problem was due to the wrong usage of `_x()` function. It can be easily resolved by using the proper function and updating the translation files.