### PR TITLE
Remove duplicated slash in new file path when saving files in a question.

### DIFF
--- a/lib/form/class-editor.php
+++ b/lib/form/class-editor.php
@@ -228,7 +228,7 @@ class Editor extends Field {
 			if ( in_array( $basename, $files, true ) ) {
 				$this->images[] = $basename;
 
-				$newfile = $upload_dir . "/$basename";
+				$newfile = $upload_dir . $basename;
 
 				$new_file_url = $uploads['baseurl'] . "/anspress-uploads/$basename";
 				rename( $uploads['basedir'] . "/anspress-temp/$basename", $newfile );


### PR DESCRIPTION
The variable $newfile contains a duplicated slash in path definition which works fine at filesystem level. However, this provokes a problem when storing files in a cloud service like S3. The key in S3 is the value of $newfile which at the moment temp file was renamed to the new name, contained an extra slash before $basename.

This issue creates an inconsistency between $newfile and $new_file_url (note that there is no duplicated slash in $new_file_url). 