### PR TITLE
Rename DS constant

### DIFF
--- a/anspress-question-answer.php
+++ b/anspress-question-answer.php
@@ -255,7 +255,7 @@ if ( ! class_exists( 'AnsPress' ) ) {
 		private function setup_constants() {
 			$plugin_dir = wp_normalize_path( plugin_dir_path( __FILE__ ) );
 
-			define( 'DS', DIRECTORY_SEPARATOR );
+			define( 'ANSPRESS_DIR_SEP', DIRECTORY_SEPARATOR );
 			define( 'AP_VERSION', $this->_plugin_version );
 			define( 'ANSPRESS_DIR', $plugin_dir );
 			define( 'ANSPRESS_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1605,7 +1605,7 @@ function ap_get_addons() {
 
 	$all_files = array();
 	foreach ( array( 'pro', 'free' ) as $folder ) {
-		$path = ANSPRESS_ADDONS_DIR . DS . $folder;
+		$path = ANSPRESS_ADDONS_DIR . ANSPRESS_DIR_SEP . $folder;
 
 		if ( file_exists( $path ) ) {
 			$files = scandir( $path );
@@ -1614,7 +1614,7 @@ function ap_get_addons() {
 				$ext = pathinfo( $file, PATHINFO_EXTENSION );
 
 				if ( 'php' === $ext ) {
-					$all_files[] = $folder . DS . $file;
+					$all_files[] = $folder . ANSPRESS_DIR_SEP . $file;
 				}
 			}
 		}


### PR DESCRIPTION
Rename the generic DS constant to ANSPRESS_DIR_SEP to keep it more inline with other constant names and prevent collisions with other plugins.