### PR TITLE
Remove bad style

### DIFF
--- a/templates/scss/reset.scss
+++ b/templates/scss/reset.scss
@@ -161,7 +161,7 @@
 		box-sizing: border-box;
 	}
 }
-.entry-content a:visited, .ap-comment-content a:visited {
+.ap-comment-content a:visited {
 	color: inherit;
 }
 


### PR DESCRIPTION
This is a horrible style and should never be in any plugin. These breaks bootstrap buttons and many other things. It makes every visited link have no colors. Not sure if this way a mistake but its way to specific for a plugin.