### PR TITLE
[Fix] Select all menu items created via AnsPress plugin reloads the custom menu management page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,39 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+### Desktop (please complete the following information):
+
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+### Smartphone (please complete the following information):
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+### Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -506,19 +506,17 @@ class AnsPress_Admin {
 
 			<p class="button-controls">
 				<span class="list-controls">
-					<a href="
 					<?php
-						echo esc_url(
-							add_query_arg(
-								array(
-									'anspress-all' => 'all',
-									'selectall'    => 1,
-								),
-								remove_query_arg( $removed_args )
-							)
-						);
+					$url = add_query_arg(
+						array(
+							'anspress-all' => 'all',
+							'selectall'    => 1,
+						),
+						remove_query_arg( $removed_args )
+					);
+					$url = $url . '#anspress-menu-mb';
 					?>
-					#anspress-menu-mb" class="select-all"><?php esc_attr_e( 'Select All', 'anspress-question-answer' ); ?></a>
+					<a href="<?php echo esc_url( $url ); ?>" class="select-all"><?php esc_attr_e( 'Select All', 'anspress-question-answer' ); ?></a>
 				</span>
 
 				<span class="add-to-menu">
@@ -684,7 +682,7 @@ class AnsPress_Admin {
 				'show'    => ( ! self::check_pages_exists() ),
 			),
 		);
-		
+
 		/**
 		 * Filter the AnsPress admin notices before they're output.
 		 *

--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -516,7 +516,7 @@ class AnsPress_Admin {
 					);
 					$url = $url . '#anspress-menu-mb';
 					?>
-					<a href="<?php echo esc_url( $url ); ?>" class="select-all"><?php esc_attr_e( 'Select All', 'anspress-question-answer' ); ?></a>
+					<a href="<?php echo esc_url( $url ); ?>" class="select-all anspress-menu-mb"><?php esc_attr_e( 'Select All', 'anspress-question-answer' ); ?></a>
 				</span>
 
 				<span class="add-to-menu">

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -849,6 +849,19 @@ jQuery(document).ready(function ($) {
 		e.preventDefault();
 		$(this).parent().remove();
 	})
+
+	$( '.anspress-menu-mb' ).on( 'click', function() {
+		let checkBoxes = $( this ).closest( '#tabs-panel-anspress-all' );
+		let checked = checkBoxes.find( '.menu-item-checkbox' );
+
+		if ( $( this ).data( 'checked' ) ) {
+			checked.prop( 'checked', false );
+			$( this ).data( 'checked', false );
+		} else {
+			checked.prop( 'checked', true );
+			$( this ).data( 'checked', true );
+		}
+	} );
 });
 
 window.AnsPress.Helper = {

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -850,7 +850,8 @@ jQuery(document).ready(function ($) {
 		$(this).parent().remove();
 	})
 
-	$( '.anspress-menu-mb' ).on( 'click', function() {
+	$( '#tabs-panel-anspress-all' ).on( 'click', '.anspress-menu-mb', function( event ) {
+		event.preventDefault();
 		let checkBoxes = $( this ).closest( '#tabs-panel-anspress-all' );
 		let checked = checkBoxes.find( '.menu-item-checkbox' );
 


### PR DESCRIPTION
This PR includes:

* Fixes the page reload issue for the **Select All** button link in the custom menu management page regarding AnsPress plugin's pages