### PR TITLE
[Fix] Some of the allowed tags is not working on email notifications set via Email Templates options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,39 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+### Desktop (please complete the following information):
+
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+### Smartphone (please complete the following information):
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+### Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/addons/email/class-helper.php
+++ b/addons/email/class-helper.php
@@ -90,7 +90,7 @@ class Helper {
 	public function __construct( $event, $args = array() ) {
 		$this->event = $event;
 
-		$this->args = wp_parse_args(
+		$this->args = ap_parse_args(
 			$args,
 			array(
 				'users'    => array(),

--- a/addons/email/email.php
+++ b/addons/email/email.php
@@ -588,6 +588,7 @@ class Email extends \AnsPress\Singleton {
 				'question_title' => $answer->post_title,
 				'answer_link'    => get_permalink( $answer->ID ),
 				'answer_content' => $answer->post_content,
+				'{answer_excerpt}' => ap_truncate_chars( wp_strip_all_tags( $answer->post_content ), 100 ),
 			)
 		);
 

--- a/admin/views/emails.php
+++ b/admin/views/emails.php
@@ -28,7 +28,7 @@ $i = 1;
 			<td>
 				<p>
 					<?php esc_attr_e( 'More email options can be found in addon options', 'anspress-question-answer' ); ?>
-					<a class="button" href="<?php echo esc_url( admin_url( 'admin.php?page=anspress_addons&active_addon=free%2Femail.php' ) ); ?>">
+					<a class="button" href="<?php echo esc_url( admin_url( 'admin.php?page=anspress_options&active_tab=features#features-email' ) ); ?>">
 						<?php esc_attr_e( 'More email options', 'anspress-question-answer' ); ?>
 					</a>
 				</p>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2498,3 +2498,27 @@ function ap_get_current_timestamp() {
 
 	return $local_time->getTimestamp() + $local_time->getOffset();
 }
+
+/**
+ * Merges user defined array arguments into the defaults array,
+ * which works with arrays only.
+ *
+ * @param array $args     Value to be merged with the defaults array.
+ * @param array $defaults Array that serves as the defaults.
+ *
+ * @return array Merged user defined values with the default array.
+ * @since 4.4.0
+ */
+function ap_parse_args( $args, $defaults ) {
+	$new_args = (array) $defaults;
+
+	foreach ( $args as $key => $value ) {
+		if ( is_array( $value ) && isset( $new_args[ $key ] ) ) {
+			$new_args[ $key ] = ap_parse_args( $value, $new_args[ $key ] );
+		} else {
+			$new_args[ $key ] = $value;
+		}
+	}
+
+	return $new_args;
+}


### PR DESCRIPTION
This PR includes:

* Fix the **{site_name}**, **{site_url}**, and **{site_description}** smart tags for email delivery change to required contents for **New Question**, **New Answer**, and **New Comment** email templates
* Fix the **{answer_excerpt}** smart tags for email delivery change to required contents for **Edit Answer** email templates
* Fix the **More email options** link available in the **Email Templates** option