### PR TITLE
[Fix] Question and Answer action links title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,39 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+### Desktop (please complete the following information):
+
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+### Smartphone (please complete the following information):
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+### Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/includes/ajax-hooks.php
+++ b/includes/ajax-hooks.php
@@ -175,7 +175,11 @@ class AnsPress_Ajax {
 					'action'      => array(
 						'active' => false,
 						'label'  => __( 'Delete', 'anspress-question-answer' ),
-						'title'  => __( 'Delete this post (can be restored again)', 'anspress-question-answer' ),
+						'title'  => sprintf(
+							/* Translators: %s Question or Answer post type label for deleting a question or answer. */
+							__( 'Delete this %s (can be restored again)', 'anspress-question-answer' ),
+							( 'question' === $post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+						),
 					),
 					// translators: %s post type.
 					'snackbar'    => array( 'message' => sprintf( __( '%s is restored', 'anspress-question-answer' ), $post_type ) ),
@@ -209,7 +213,11 @@ class AnsPress_Ajax {
 				'action'      => array(
 					'active' => true,
 					'label'  => __( 'Undelete', 'anspress-question-answer' ),
-					'title'  => __( 'Restore this post', 'anspress-question-answer' ),
+					'title'  => sprintf(
+						/* Translators: %s Question or Answer post type label for restoring a question or answer. */
+						__( 'Restore this %s', 'anspress-question-answer' ),
+						( 'question' === $post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+					),
 				),
 				// translators: %s is post type.
 				'snackbar'    => array( 'message' => sprintf( __( '%s is trashed', 'anspress-question-answer' ), $post_type ) ),

--- a/includes/flag.php
+++ b/includes/flag.php
@@ -128,7 +128,19 @@ function ap_flag_btn_args( $post = null ) {
 	$_post   = ap_get_post( $post );
 	$flagged = ap_is_user_flagged( $_post );
 
-	$title = ( ! $flagged ) ? ( __( 'Flag this post', 'anspress-question-answer' ) ) : ( __( 'You have flagged this post', 'anspress-question-answer' ) );
+	if ( ! $flagged ) {
+		$title = sprintf(
+			/* Translators: %s Question or Answer post type label for flagging question or answer. */
+			__( 'Flag this %s', 'anspress-question-answer' ),
+			( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+		);
+	} else {
+		$title = sprintf(
+			/* Translators: %s Question or Answer post type label for already flagged question or answer. */
+			__( 'You have flagged this %s', 'anspress-question-answer' ),
+			( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+		);
+	}
 
 	$actions['close'] = array(
 		'cb'     => 'flag',

--- a/includes/theme.php
+++ b/includes/theme.php
@@ -326,7 +326,11 @@ function ap_post_actions( $_post = null ) {
 				'__nonce' => wp_create_nonce( 'delete_post_' . $_post->ID ),
 			),
 			'label' => __( 'Delete Permanently', 'anspress-question-answer' ),
-			'title' => __( 'Delete post permanently (cannot be restored again)', 'anspress-question-answer' ),
+			'title' => sprintf(
+				/* Translators: %s Question or Answer post type label for permanently deleting a question or answer. */
+				__( 'Delete %s permanently (cannot be restored again)', 'anspress-question-answer' ),
+				( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+			),
 		);
 	}
 

--- a/includes/theme.php
+++ b/includes/theme.php
@@ -292,10 +292,18 @@ function ap_post_actions( $_post = null ) {
 	if ( ap_user_can_delete_post( $_post->ID ) ) {
 		if ( 'trash' === $_post->post_status ) {
 			$label = __( 'Undelete', 'anspress-question-answer' );
-			$title = __( 'Restore this post', 'anspress-question-answer' );
+			$title = sprintf(
+				/* Translators: %s Question or Answer post type label for restoring a question or answer. */
+				__( 'Restore this %s', 'anspress-question-answer' ),
+				( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+			);
 		} else {
 			$label = __( 'Delete', 'anspress-question-answer' );
-			$title = __( 'Delete this post (can be restored again)', 'anspress-question-answer' );
+			$title = sprintf(
+				/* Translators: %s Question or Answer post type label for deleting a question or answer. */
+				__( 'Delete this %s (can be restored again)', 'anspress-question-answer' ),
+				( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+			);
 		}
 
 		$actions[] = array(


### PR DESCRIPTION
This PR includes:

* Modify the post action links title for **Flag this post**, **Delete this post (can be restored again)**, and **Delete post permanently (cannot be restored again)** to render the respective Question or Answer post type label instead of showing post