### PR TITLE
[Fix] Post status for Question and Answer post types not displaying in Question and Answer edit page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,39 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+### Desktop (please complete the following information):
+
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+### Smartphone (please complete the following information):
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+### Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -67,6 +67,7 @@ class AnsPress_Admin {
 		anspress()->add_filter( 'posts_clauses', __CLASS__, 'join_by_author_name', 10, 2 );
 		anspress()->add_action( 'get_pages', __CLASS__, 'get_pages', 10, 2 );
 		anspress()->add_action( 'wp_insert_post_data', __CLASS__, 'modify_answer_title', 10, 2 );
+		anspress()->add_action( 'admin_footer-edit.php', __CLASS__, 'append_post_status_list_edit' );
 		anspress()->add_action( 'admin_footer-post.php', __CLASS__, 'append_post_status_list' );
 		anspress()->add_action( 'admin_footer-post-new.php', __CLASS__, 'append_post_status_list' );
 		anspress()->add_action( 'admin_post_anspress_update_db', __CLASS__, 'update_db' );
@@ -631,6 +632,24 @@ class AnsPress_Admin {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Add AnsPress post status to bulk edit select box.
+	 */
+	public static function append_post_status_list_edit() {
+		global $post;
+
+		if ( in_array( $post->post_type, array( 'question', 'answer' ), true ) ) {
+			// @codingStandardsIgnoreStart
+			echo '<script>
+				jQuery( document ).ready( function() {
+					jQuery( ".inline-edit-group select[name=\'_status\']" ).append( "<option value=\'moderate\'>' . esc_attr__( 'Moderate', 'anspress-question-answer' ) . '</option>" );
+					jQuery( ".inline-edit-group select[name=\'_status\']" ).append( "<option value=\'private_post\'>' . esc_attr__( 'Private Post', 'anspress-question-answer' ) . '</option>" );
+				} );
+			</script>';
+			// @codingStandardsIgnoreEnd
+		}
 	}
 
 	/**

--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -68,6 +68,7 @@ class AnsPress_Admin {
 		anspress()->add_action( 'get_pages', __CLASS__, 'get_pages', 10, 2 );
 		anspress()->add_action( 'wp_insert_post_data', __CLASS__, 'modify_answer_title', 10, 2 );
 		anspress()->add_action( 'admin_footer-post.php', __CLASS__, 'append_post_status_list' );
+		anspress()->add_action( 'admin_footer-post-new.php', __CLASS__, 'append_post_status_list' );
 		anspress()->add_action( 'admin_post_anspress_update_db', __CLASS__, 'update_db' );
 		anspress()->add_action( 'admin_post_anspress_create_base_page', __CLASS__, 'anspress_create_base_page' );
 		anspress()->add_action( 'admin_notices', __CLASS__, 'anspress_notice' );

--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -637,26 +637,22 @@ class AnsPress_Admin {
 	 */
 	public static function append_post_status_list() {
 		global $post;
-
-		$complete = '';
-		$label    = '';
+		$label = '';
 
 		if ( in_array( $post->post_type, array( 'question', 'answer' ), true ) ) {
 			if ( 'moderate' === $post->post_status ) {
-					$complete = ' selected=\'selected\'';
-					$label    = '<span id=\'post-status-display\'>' . esc_attr__( 'Moderate', 'anspress-question-answer' ) . '</span>';
+				$label = esc_attr__( 'Moderate', 'anspress-question-answer' );
 			} elseif ( 'private_post' === $post->post_status ) {
-					$complete = ' selected=\'selected\'';
-					$label    = '<span id=\'post-status-display\'>' . esc_attr__( 'Private Post', 'anspress-question-answer' ) . '</span>';
+				$label = esc_attr__( 'Private Post', 'anspress-question-answer' );
 			}
 
 			// @codingStandardsIgnoreStart
 			echo '<script>
-				jQuery(document).ready(function(){
-					jQuery("select#post_status").append("<option value=\'moderate\' ' . $complete . '>' . esc_attr__( 'Moderate', 'anspress-question-answer' ) . '</option>");
-					jQuery("select#post_status").append("<option value=\'private_post\' ' . $complete . '>' . esc_attr__( 'Private Post', 'anspress-question-answer' ) . '</option>");
-					jQuery(".misc-pub-section label").append("' . $label . '");
-				});
+				jQuery( document ).ready( function() {
+					jQuery( "select#post_status" ).append( "<option value=\'moderate\'' . ( 'moderate' === $post->post_status ? ' selected=\'selected\'' : '' ) . '>' . esc_attr__( 'Moderate', 'anspress-question-answer' ) . '</option>" );
+					jQuery( "select#post_status" ).append( "<option value=\'private_post\'' . ( 'private_post' === $post->post_status ? ' selected=\'selected\'' : '' ) . '>' . esc_attr__( 'Private Post', 'anspress-question-answer' ) . '</option>" );'
+					. ( ( 'moderate' === $post->post_status || 'private_post' === $post->post_status ) ? 'jQuery( "select#post_status" ).closest( ".misc-pub-section" ).find( "#post-status-display" ).html( "' . $label . '" );' : '' ) . '
+				} );
 			</script>';
 			// @codingStandardsIgnoreEnd
 		}
@@ -684,7 +680,7 @@ class AnsPress_Admin {
 				'show'    => ( ! self::check_pages_exists() ),
 			),
 		);
-		
+
 		/**
 		 * Filter the AnsPress admin notices before they're output.
 		 *


### PR DESCRIPTION
This PR includes:

* Fixes the post status display in the dashboard for **Question** and **Answer** post type edit page when set to **Moderate** or **Private Post** status for them
* Fixes the double post status selected on value for post status select option when the post status of **Moderate** or **Private Post** is selected for Question or Answer post type and viewing their respective edit page
* Add **Moderate** and **Private Post** post status to the newly created **Question** and **Answer** post type contents
* Add **Moderate** and **Private Post** post status to the bulk edit page of **Question** and **Answer** post type 