### PR TITLE
[Fix] Attempt to read property name on bool

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,39 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+### Desktop (please complete the following information):
+
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+### Smartphone (please complete the following information):
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+### Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/addons/tags/tags.php
+++ b/addons/tags/tags.php
@@ -459,7 +459,7 @@ class Tags extends \AnsPress\Singleton {
 	public function ap_breadcrumbs( $navs ) {
 		if ( is_question_tag() ) {
 			$tag_id       = sanitize_title( get_query_var( 'q_tag' ) );
-			$tag = get_term_by( 'slug', $tag_id, 'question_tag' ); // @codingStandardsIgnoreLine.
+			$tag          = $tag_id ? get_term_by( 'slug', $tag_id, 'question_tag' ) : get_queried_object(); // @codingStandardsIgnoreLine.
 			$navs['page'] = array(
 				'title' => __( 'Tags', 'anspress-question-answer' ),
 				'link'  => ap_get_link_to( 'tags' ),

--- a/addons/tags/tags.php
+++ b/addons/tags/tags.php
@@ -443,7 +443,7 @@ class Tags extends \AnsPress\Singleton {
 			$title = ap_opt( 'tags_page_title' );
 		} elseif ( is_question_tag() ) {
 			$tag_id = sanitize_title( get_query_var( 'q_tag' ) );
-			$tag = get_term_by( 'slug', $tag_id, 'question_tag' ); // @codingStandardsIgnoreLine.
+			$tag    = $tag_id ? get_term_by( 'slug', $tag_id, 'question_tag' ) : get_queried_object(); // @codingStandardsIgnoreLine.
 			$title  = $tag->name;
 		}
 

--- a/includes/taxo.php
+++ b/includes/taxo.php
@@ -430,7 +430,7 @@ function ap_question_have_tags( $question_id = false ) {
  * @return bool
  */
 function is_question_tag() {
-	if ( ap_get_tag_slug() === get_query_var( 'ap_page' ) ) {
+	if ( 'tag' === ap_current_page() ) {
 		return true;
 	}
 
@@ -443,7 +443,7 @@ function is_question_tag() {
  * @return bool
  */
 function is_question_tags() {
-	if ( ap_get_tags_slug() === get_query_var( 'ap_page' ) ) {
+	if ( 'tags' === ap_current_page() ) {
 		return true;
 	}
 


### PR DESCRIPTION
This PR includes:

* PHP warning to be logged into debug log file if **(AnsPress) Breadcrumbs** widget is used in the **(AnsPress) Question List** Top widgetized area and viewing the individual tag page
* Fixes the display of the single tag item in the single tag page and Tags item in the tags archive page for the **(AnsPress) Breadcrumbs** widget
* Fixes the condition to check for currently viewing page is either a tag page or tags archive page