### PR TITLE
[Fix] Deleting comment, question, and answer is done without notifying the user

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,39 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+### Desktop (please complete the following information):
+
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+### Smartphone (please complete the following information):
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+### Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -370,6 +370,7 @@ _.templateSettings = {
 		clickHide: function (e) {
 			e.preventDefault();
 			this.hide();
+			apToggleLoadedClass();
 		},
 		hide: function (runCb) {
 			if (typeof runCb === 'undefined')
@@ -777,6 +778,7 @@ jQuery(document).ready(function ($) {
 			if ($lastModal.length > 0) {
 				$name = $lastModal.attr('id').replace('ap-modal-', '');
 				AnsPress.hideModal($name);
+				apToggleLoadedClass();
 			}
 		}
 	});
@@ -865,6 +867,22 @@ jQuery(document).ready(function ($) {
 		$(this).parent().remove();
 	})
 });
+
+/**
+ * Remove loaded class whenever needed.
+ */
+function apToggleLoadedClass() {
+	// For the event to be triggered once again.
+	const loadedClass = [
+		'.comment-edit',
+	];
+	jQuery.each( loadedClass, function( i, loadedClassName ) {
+		const elem = jQuery( loadedClassName );
+		if ( elem.hasClass( 'loaded' ) ) {
+			elem.removeClass( 'loaded' );
+		}
+	} );
+}
 
 window.AnsPress.Helper = {
 	toggleNextClass: function (el) {

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -588,8 +588,23 @@ jQuery(document).ready(function ($) {
 			return;
 
 		var self = $(this);
-		var query = JSON.parse(self.attr('apquery'));
+		const string = aplang.ajax_events.replace( '%s', self.attr( 'title' ) );
+		const apAjaxEventClass = [
+			'comment-delete',
+		];
+		let eventTrigger = true;
+		$.each( apAjaxEventClass, function( i, eventClassName ) {
+			if ( self.hasClass( eventClassName ) ) {
+				if ( ! confirm( string ) ) {
+					eventTrigger = false;
+				}
+			}
+		} );
+		if ( ! eventTrigger ) {
+			return;
+		}
 
+		var query = JSON.parse(self.attr('apquery'));
 		AnsPress.showLoading(self);
 		AnsPress.ajax({
 			data: query,

--- a/assets/js/question.js
+++ b/assets/js/question.js
@@ -65,6 +65,7 @@
 			const apAjaxEventClass = [
 				'delete',
 				'delete-permanently',
+				'convert-to-post',
 			];
 			let eventTrigger = true;
 			$.each( apAjaxEventClass, function( i, eventClassName ) {

--- a/assets/js/question.js
+++ b/assets/js/question.js
@@ -33,7 +33,7 @@
 			return this.postID;
 		},
 		className: function () {
-			var klass = '';
+			var klass = this.model.get( 'label' ).replaceAll( ' ', '-' ).toLowerCase();
 			if (this.model.get('header')) klass += ' ap-dropdown-header';
 			if (this.model.get('active')) klass += ' active';
 			return klass;
@@ -61,6 +61,23 @@
 				return;
 
 			e.preventDefault();
+			const string = aplang.ajax_events.replace( '%s', $( e.target ).attr( 'title' ) );
+			const apAjaxEventClass = [
+				'delete',
+				'delete-permanently',
+			];
+			let eventTrigger = true;
+			$.each( apAjaxEventClass, function( i, eventClassName ) {
+				if ( $( e.target ).closest( 'li' ).hasClass( eventClassName ) ) {
+					if ( ! confirm( string ) ) {
+						eventTrigger = false;
+					}
+				}
+			} );
+			if ( ! eventTrigger ) {
+				return;
+			}
+
 			var self = this;
 			AnsPress.showLoading(e.target);
 			var cb = this.model.get('cb');

--- a/includes/comments.php
+++ b/includes/comments.php
@@ -257,6 +257,7 @@ function ap_comment_actions( $comment ) {
 
 	if ( ap_user_can_edit_comment( $comment->comment_ID ) ) {
 		$actions[] = array(
+			'title' => __( 'Edit this Comment', 'anspress-question-answer' ),
 			'label' => __( 'Edit', 'anspress-question-answer' ),
 			'href'  => '#',
 			'query' => array(
@@ -269,6 +270,7 @@ function ap_comment_actions( $comment ) {
 
 	if ( ap_user_can_delete_comment( $comment->comment_ID ) ) {
 		$actions[] = array(
+			'title' => __( 'Delete this Comment', 'anspress-question-answer' ),
 			'label' => __( 'Delete', 'anspress-question-answer' ),
 			'href'  => '#',
 			'query' => array(
@@ -281,6 +283,7 @@ function ap_comment_actions( $comment ) {
 
 	if ( '0' === $comment->comment_approved && ap_user_can_approve_comment() ) {
 		$actions[] = array(
+			'title' => __( 'Approve this Comment', 'anspress-question-answer' ),
 			'label' => __( 'Approve', 'anspress-question-answer' ),
 			'href'  => '#',
 			'query' => array(

--- a/templates/comment.php
+++ b/templates/comment.php
@@ -38,6 +38,7 @@ $approved = '1' != $comment->comment_approved ? 'unapproved' : 'approved'; // ph
 				<div class="ap-comment-actions">
 					<?php foreach ( ap_comment_actions( $comment ) as $comment_action ) : ?>
 						<a href="<?php echo esc_url( $comment_action['href'] ); ?>"
+							<?php echo ' class="comment-' . esc_attr( str_replace( ' ', '-', strtolower( $comment_action['label'] ) ) ) . '"'; ?>
 							<?php echo ! empty( $comment_action['title'] ) ? ' title="' . esc_attr( $comment_action['title'] ) . '"' : ''; ?>
 							<?php echo ! empty( $comment_action['query'] ) ? ' apajaxbtn apquery="' . esc_js( wp_json_encode( $comment_action['query'] ) ) . '"' : ''; ?>
 							>

--- a/templates/functions.php
+++ b/templates/functions.php
@@ -52,6 +52,8 @@ function ap_scripts_front() {
 		'mark_all_seen'          => __( 'Mark all as seen', 'anspress-question-answer' ),
 		'search'                 => __( 'Search', 'anspress-question-answer' ),
 		'no_permission_comments' => __( 'Sorry, you don\'t have permission to read comments.', 'anspress-question-answer' ),
+		/* translators: %s: Ajax event. */
+		'ajax_events'            => __( 'Are you sure you want to %s?', 'anspress-question-answer' ),
 	);
 
 	echo '<script type="text/javascript">';


### PR DESCRIPTION
This PR includes:

* Tweak - Delete the user comments from the front end only after the user confirms this action
* Tweak - Delete and delete permanently the user questions and answers from the front end only after the user confirms this action
* Tweak - Question change to a post from the front end only after the user confirms this action