### PR TITLE
[Fix] [BuddyPress Integration] Comments to answers not displayed in activity?

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,39 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
+
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+### Desktop (please complete the following information):
+
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+### Smartphone (please complete the following information):
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
-**Additional context**
+### Additional context
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/addons/buddypress/buddypress.php
+++ b/addons/buddypress/buddypress.php
@@ -317,30 +317,46 @@ class BuddyPress extends \AnsPress\Singleton {
 		bp_activity_set_post_type_tracking_args(
 			'question',
 			array(
-				'component_id'             => 'activity',
-				'action_id'                => 'new_question',
-				'contexts'                 => array( 'activity', 'member' ),
-				'bp_activity_admin_filter' => __( 'Question', 'anspress-question-answer' ),
-				'bp_activity_front_filter' => __( 'Question', 'anspress-question-answer' ),
+				'component_id'                      => 'activity',
+				'action_id'                         => 'new_question',
+				'contexts'                          => array( 'activity', 'member' ),
+				'bp_activity_admin_filter'          => __( 'Question', 'anspress-question-answer' ),
+				'bp_activity_front_filter'          => __( 'Question', 'anspress-question-answer' ),
 				// translators: First placeholder contains user link and name.
-				'bp_activity_new_post'     => __( '%1$s asked a new <a href="AP_CPT_LINK">question</a>', 'anspress-question-answer' ),
+				'bp_activity_new_post'              => __( '%1$s asked a new <a href="AP_CPT_LINK">question</a>', 'anspress-question-answer' ),
 				// translators: First placeholder contains user link and name.
-				'bp_activity_new_post_ms'  => __( '%1$s asked a new <a href="AP_CPT_LINK">question</a>, on the site %3$s', 'anspress-question-answer' ),
+				'bp_activity_new_post_ms'           => __( '%1$s asked a new <a href="AP_CPT_LINK">question</a>, on the site %3$s', 'anspress-question-answer' ),
+				'activity_comment'                  => true,
+				'comment_action_id'                 => 'new_comment_question',
+				'bp_activity_comments_admin_filter' => __( 'Commented on Question', 'anspress-question-answer' ),
+				'bp_activity_comments_front_filter' => __( 'Commented on Question', 'anspress-question-answer' ),
+				// translators: First placeholder contains user link and name.
+				'bp_activity_new_comment'           => __( '%1$s commented on <a href="%2$s">question</a>', 'anspress-question-answer' ),
+				// translators: First placeholder contains user link and name.
+				'bp_activity_new_comment_ms'        => __( '%1$s commented on <a href="%2$s">question</a>, on the site %3$s', 'anspress-question-answer' ),
 			)
 		);
 
 		bp_activity_set_post_type_tracking_args(
 			'answer',
 			array(
-				'component_id'             => 'activity',
-				'action_id'                => 'new_answer',
-				'contexts'                 => array( 'activity', 'member' ),
-				'bp_activity_admin_filter' => __( 'Answer', 'anspress-question-answer' ),
-				'bp_activity_front_filter' => __( 'Answer', 'anspress-question-answer' ),
+				'component_id'                      => 'activity',
+				'action_id'                         => 'new_answer',
+				'contexts'                          => array( 'activity', 'member' ),
+				'bp_activity_admin_filter'          => __( 'Answer', 'anspress-question-answer' ),
+				'bp_activity_front_filter'          => __( 'Answer', 'anspress-question-answer' ),
 				// translators: First placeholder contains user name and link.
-				'bp_activity_new_post'     => __( '%1$s <a href="AP_CPT_LINK">answered</a> a question', 'anspress-question-answer' ),
+				'bp_activity_new_post'              => __( '%1$s <a href="AP_CPT_LINK">answered</a> a question', 'anspress-question-answer' ),
 				// translators: First placeholder contains user name and link.
-				'bp_activity_new_post_ms'  => __( '%1$s <a href="AP_CPT_LINK">answered</a> a question, on the site %3$s', 'anspress-question-answer' ),
+				'bp_activity_new_post_ms'           => __( '%1$s <a href="AP_CPT_LINK">answered</a> a question, on the site %3$s', 'anspress-question-answer' ),
+				'activity_comment'                  => true,
+				'comment_action_id'                 => 'new_comment_answer',
+				'bp_activity_comments_admin_filter' => __( 'Commented on Answer', 'anspress-question-answer' ),
+				'bp_activity_comments_front_filter' => __( 'Commented on Answer', 'anspress-question-answer' ),
+				// translators: First placeholder contains user link and name.
+				'bp_activity_new_comment'           => __( '%1$s commented on <a href="%2$s">answer</a>', 'anspress-question-answer' ),
+				// translators: First placeholder contains user link and name.
+				'bp_activity_new_comment_ms'        => __( '%1$s commented on <a href="%2$s">answer</a>, on the site %3$s', 'anspress-question-answer' ),
 			)
 		);
 	}

--- a/templates/buddypress/question-item.php
+++ b/templates/buddypress/question-item.php
@@ -45,7 +45,7 @@ if ( ! ap_user_can_view_post( get_the_ID() ) ) {
 				<a href="<?php the_permalink(); ?>" class="apicon-answer ap-bpsingle-acount">
 					<?php
 						// translators: %d is total answer count.
-						echo esc_attr( printf( _n( '%d Answer', '%d Answers', ap_get_answers_count(), 'anspress-question-answer' ), ap_get_answers_count() ) );
+						echo esc_attr( sprintf( _n( '%d Answer', '%d Answers', ap_get_answers_count(), 'anspress-question-answer' ), ap_get_answers_count() ) );
 					?>
 				</a>
 


### PR DESCRIPTION
This PR includes:

* Comments on question and answer is now logged to the BuddyPress activity
* Fixes unrequired number display after answers number on the Users' Questions page, when viewing the user profile Questions' page via the BuddyPress addon enabled 