### PR TITLE
[Fix] PHP warning on (AnsPress) Categories widget

### DIFF
--- a/addons/categories/widget.php
+++ b/addons/categories/widget.php
@@ -71,6 +71,9 @@ class Categories extends \WP_Widget {
 			'order'      => $instance['order'],
 		);
 
+		$icon_width  = ( ! empty( $instance['icon_width'] ) && is_numeric( $instance['icon_width'] ) ) ? $instance['icon_width'] : 32;
+		$icon_height = ( ! empty( $instance['icon_height'] ) && is_numeric( $instance['icon_height'] ) ) ? $instance['icon_height'] : 32;
+
 		$categories = get_terms( $cat_args );
 		?>
 		<ul id="ap-categories-widget" class="ap-cat-wid clearfix">
@@ -87,7 +90,7 @@ class Categories extends \WP_Widget {
 			$sub_cat_count = count( get_term_children( $category->term_id, 'question_category' ) );
 			?>
 			<li class="clearfix">
-			<a class="ap-cat-image" style="height:<?php echo esc_attr( $instance['icon_height'] ); ?>px;width:<?php echo esc_attr( $instance['icon_width'] ); ?>px;background: <?php echo esc_attr( $ap_category['color'] ); ?>" href="<?php echo esc_url( get_category_link( $category ) ); ?>">
+			<a class="ap-cat-image" style="height:<?php echo esc_attr( $icon_height ); ?>px;width:<?php echo esc_attr( $icon_width ); ?>px;background: <?php echo esc_attr( $ap_category['color'] ); ?>" href="<?php echo esc_url( get_category_link( $category ) ); ?>">
 				<span class="ap-category-icon <?php echo esc_attr( $ap_category['icon'] ); ?>"></span>
 			</a>
 			<a class="ap-cat-wid-title" href="<?php echo esc_url( get_category_link( $category ) ); ?>">

--- a/addons/categories/widget.php
+++ b/addons/categories/widget.php
@@ -37,6 +37,20 @@ class Categories extends \WP_Widget {
 	 * @param array $instance Widget instance.
 	 */
 	public function widget( $args, $instance ) {
+		$instance = wp_parse_args(
+			$instance,
+			array(
+				'title'       => __( 'Categories', 'anspress-question-answer' ),
+				'hide_empty'  => false,
+				'parent'      => 0,
+				'number'      => 10,
+				'orderby'     => 'count',
+				'order'       => 'DESC',
+				'icon_width'  => 32,
+				'icon_height' => 32,
+			)
+		);
+
 		/**
 		 * This filter is documented in widgets/question_stats.php
 		 */
@@ -57,9 +71,6 @@ class Categories extends \WP_Widget {
 			'order'      => $instance['order'],
 		);
 
-		$icon_width  = ! empty( $instance['icon_width'] ) ? $instance['icon_width'] : 32;
-		$icon_height = ! empty( $instance['icon_height'] ) ? $instance['icon_height'] : 32;
-
 		$categories = get_terms( $cat_args );
 		?>
 		<ul id="ap-categories-widget" class="ap-cat-wid clearfix">
@@ -76,7 +87,7 @@ class Categories extends \WP_Widget {
 			$sub_cat_count = count( get_term_children( $category->term_id, 'question_category' ) );
 			?>
 			<li class="clearfix">
-			<a class="ap-cat-image" style="height:<?php echo esc_attr( $icon_height ); ?>px;width:<?php echo esc_attr( $icon_width ); ?>px;background: <?php echo esc_attr( $ap_category['color'] ); ?>" href="<?php echo esc_url( get_category_link( $category ) ); ?>">
+			<a class="ap-cat-image" style="height:<?php echo esc_attr( $instance['icon_height'] ); ?>px;width:<?php echo esc_attr( $instance['icon_width'] ); ?>px;background: <?php echo esc_attr( $ap_category['color'] ); ?>" href="<?php echo esc_url( get_category_link( $category ) ); ?>">
 				<span class="ap-category-icon <?php echo esc_attr( $ap_category['icon'] ); ?>"></span>
 			</a>
 			<a class="ap-cat-wid-title" href="<?php echo esc_url( get_category_link( $category ) ); ?>">

--- a/addons/categories/widget.php
+++ b/addons/categories/widget.php
@@ -87,10 +87,11 @@ class Categories extends \WP_Widget {
 					'icon'  => 'apicon-category',
 				)
 			);
+			$cat_color     = ! empty( $ap_category['color'] ) ? $ap_category['color'] : '#333';
 			$sub_cat_count = count( get_term_children( $category->term_id, 'question_category' ) );
 			?>
 			<li class="clearfix">
-			<a class="ap-cat-image" style="height:<?php echo esc_attr( $icon_height ); ?>px;width:<?php echo esc_attr( $icon_width ); ?>px;background: <?php echo esc_attr( $ap_category['color'] ); ?>" href="<?php echo esc_url( get_category_link( $category ) ); ?>">
+			<a class="ap-cat-image" style="height:<?php echo esc_attr( $icon_height ); ?>px;width:<?php echo esc_attr( $icon_width ); ?>px;background: <?php echo esc_attr( $cat_color ); ?>" href="<?php echo esc_url( get_category_link( $category ) ); ?>">
 				<span class="ap-category-icon <?php echo esc_attr( $ap_category['icon'] ); ?>"></span>
 			</a>
 			<a class="ap-cat-wid-title" href="<?php echo esc_url( get_category_link( $category ) ); ?>">


### PR DESCRIPTION
This PR includes:

* Fixes PHP warning message for undefined array key title when using this widget initially
* Fixes PHP warning message for undefined array key hide_empty when using this widget initially
* Fixes PHP warning message for undefined array key parent when using this widget initially
* Fixes PHP warning message for undefined array key number when using this widget initially
* Fixes PHP warning message for undefined array key orderby when using this widget initially
* Fixes PHP warning message for undefined array key order when using this widget initially