### PR TITLE
[Fix] PHP warning on Pages option save when page selected is Select an option

### DIFF
--- a/admin/views/options.php
+++ b/admin/views/options.php
@@ -138,7 +138,11 @@ if ( ! empty( $form_name ) && anspress()->get_form( $form_name )->is_submitted()
 			foreach ( $main_pages as $slug ) {
 				if ( isset( $values[ $slug ] ) ) {
 					$_post = get_post( $values[ $slug ]['value'] );
-					ap_opt( $slug . '_id', $_post->post_name );
+
+					// Proceed only if there is post available.
+					if ( $_post ) {
+						ap_opt( $slug . '_id', $_post->post_name );
+					}
 				}
 			}
 


### PR DESCRIPTION
This PR includes:

* Fixes the PHP warning message when pages option is saved with page selected as Select an option