### PR TITLE
[Fix] Welcome Page Questions Date only Displays in the Latest Question only for the same date

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -130,7 +130,7 @@ class AnsPress_Dashboard {
 						?>
 						<li>
 							<a target="_blank" href="<?php the_permalink(); ?>"><?php echo esc_html( get_the_title() ); ?></a> -
-							<span class="posted"><?php the_date(); ?></span>
+							<span class="posted"><?php echo esc_html( get_the_date() ); ?></span>
 						</li>
 					<?php endwhile; ?>
 				</ul>


### PR DESCRIPTION
This PR includes:

* Fixes the question post date display on all questions on the AnsPress Welcome Page