### PR TITLE
[Fix] Welcome Page Answers Section Empty

### DIFF
--- a/admin/views/dashboard.php
+++ b/admin/views/dashboard.php
@@ -165,6 +165,7 @@ class AnsPress_Dashboard {
 				array(
 					'ap_order_by' => 'newest',
 					'showposts'   => 5,
+					'question_id' => 'all',
 				)
 			);
 			?>
@@ -177,7 +178,7 @@ class AnsPress_Dashboard {
 						?>
 						<li>
 							<a target="_blank" href="<?php the_permalink(); ?>"><?php echo esc_html( get_the_title() ); ?></a> -
-							<span class="posted"><?php the_date(); ?></span>
+							<span class="posted"><?php echo esc_html( get_the_date() ); ?></span>
 						</li>
 					<?php endwhile; ?>
 				</ul>


### PR DESCRIPTION
This PR includes:

* Fixes the display of the answers in the Latest Answers section of the AnsPress Welcome Page
* Fixes the post date display for all answers listed in the Latest Answers section of the AnsPress Welcome Page