### PR TITLE
[Fix] Subscribed/Unsubscribed to the Question Ajax message

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -567,8 +567,8 @@ jQuery(document).ready(function ($) {
 		AnsPress.ajax({
 			data: query,
 			success: function (data) {
-				if (data.count) self.next().text(data.count);
-				if (data.label) self.text(data.label);
+				if ( data.count ) self.find( '.apsubscribers-count' ).text( data.count );
+				if ( data.label ) self.find( '.apsubscribers-title' ).text( data.label );
 			}
 		})
 	});

--- a/includes/ajax-hooks.php
+++ b/includes/ajax-hooks.php
@@ -517,7 +517,13 @@ class AnsPress_Ajax {
 			ap_ajax_json(
 				array(
 					'success'  => true,
-					'snackbar' => array( 'message' => __( 'Successfully unsubscribed from question', 'anspress-question-answer' ) ),
+					'snackbar' => array(
+						'message' => sprintf(
+							/* Translators: %s Unsubscribed to the question title */
+							__( 'Successfully unsubscribed from question: %s', 'anspress-question-answer' ),
+							$_post->post_title
+						),
+					),
 					'count'    => ap_get_post_field( 'subscribers', $post_id ),
 					'label'    => __( 'Subscribe', 'anspress-question-answer' ),
 				)
@@ -539,7 +545,13 @@ class AnsPress_Ajax {
 		ap_ajax_json(
 			array(
 				'success'  => true,
-				'snackbar' => array( 'message' => __( 'Successfully subscribed to question', 'anspress-question-answer' ) ),
+				'snackbar' => array(
+					'message' => sprintf(
+						/* Translators: %s Subscribed to the question title */
+						__( 'Successfully subscribed to question: %s', 'anspress-question-answer' ),
+						$_post->post_title
+					),
+				),
 				'count'    => ap_get_post_field( 'subscribers', $post_id ),
 				'label'    => __( 'Unsubscribe', 'anspress-question-answer' ),
 			)

--- a/includes/theme.php
+++ b/includes/theme.php
@@ -889,7 +889,7 @@ function ap_subscribe_btn( $_post = false, $output = true ) {
 	$subscribed  = ap_is_user_subscriber( 'question', $_post->ID );
 	$label       = $subscribed ? __( 'Unsubscribe', 'anspress-question-answer' ) : __( 'Subscribe', 'anspress-question-answer' );
 
-	$html = '<a href="#" class="ap-btn ap-btn-subscribe ap-btn-small ' . ( $subscribed ? 'active' : '' ) . '" apsubscribe apquery="' . esc_js( $args ) . '">' . esc_attr( $label ) . '<span class="apsubscribers-count">' . esc_attr( $subscribers ) . '</span></a>';
+	$html = '<a href="#" class="ap-btn ap-btn-subscribe ap-btn-small ' . ( $subscribed ? 'active' : '' ) . '" apsubscribe apquery="' . esc_js( $args ) . '"><span class="apsubscribers-title">' . esc_html( $label ) . '</span><span class="apsubscribers-count">' . esc_html( $subscribers ) . '</span></a>';
 
 	if ( ! $output ) {
 		return $html;


### PR DESCRIPTION
This PR includes:

* Display the question title for the question subscription/unsubscription by the user via Ajax message as well
* Fixes the display of the subscription count for the question via Ajax event on clicking the **Subscribe** or **Unsubscribe** to question button