### PR TITLE
[Fix] Quick tags editor does not work when enabled for Answer editor? plugin option

### DIFF
--- a/includes/class-form-hooks.php
+++ b/includes/class-form-hooks.php
@@ -171,7 +171,7 @@ class AP_Form_Hooks {
 					'min_length'  => ap_opt( 'minimum_ans_length' ),
 					'validate'    => 'required,min_string_length,badwords',
 					'editor_args' => array(
-						'quicktags' => ap_opt( 'question_text_editor' ) ? true : false,
+						'quicktags' => ap_opt( 'answer_text_editor' ) ? true : false,
 					),
 				),
 			),


### PR DESCRIPTION
This PR includes:

* **Answer editor?** plugin option does not render the **Quick tags editor** in the front end even though it is enabled from the plugin options page