### PR TITLE
[Fix] Select all menu items created via AnsPress plugin reloads the custom menu management page

### DIFF
--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -503,19 +503,17 @@ class AnsPress_Admin {
 
 			<p class="button-controls">
 				<span class="list-controls">
-					<a href="
 					<?php
-						echo esc_url(
-							add_query_arg(
-								array(
-									'anspress-all' => 'all',
-									'selectall'    => 1,
-								),
-								remove_query_arg( $removed_args )
-							)
-						);
+					$url = add_query_arg(
+						array(
+							'anspress-all' => 'all',
+							'selectall'    => 1,
+						),
+						remove_query_arg( $removed_args )
+					);
+					$url = $url . '#anspress-menu-mb';
 					?>
-					#anspress-menu-mb" class="select-all"><?php esc_attr_e( 'Select All', 'anspress-question-answer' ); ?></a>
+					<a href="<?php echo esc_url( $url ); ?>" class="select-all anspress-menu-mb"><?php esc_attr_e( 'Select All', 'anspress-question-answer' ); ?></a>
 				</span>
 
 				<span class="add-to-menu">

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -849,6 +849,20 @@ jQuery(document).ready(function ($) {
 		e.preventDefault();
 		$(this).parent().remove();
 	})
+
+	$( '#tabs-panel-anspress-all' ).on( 'click', '.anspress-menu-mb', function( event ) {
+		event.preventDefault();
+		let checkBoxes = $( this ).closest( '#tabs-panel-anspress-all' );
+		let checked = checkBoxes.find( '.menu-item-checkbox' );
+
+		if ( $( this ).data( 'checked' ) ) {
+			checked.prop( 'checked', false );
+			$( this ).data( 'checked', false );
+		} else {
+			checked.prop( 'checked', true );
+			$( this ).data( 'checked', true );
+		}
+	} );
 });
 
 window.AnsPress.Helper = {


### PR DESCRIPTION
This PR includes:

* Fixes the page reload issue for the **Select All** button link in the custom menu management page regarding AnsPress plugin's pages