### PR TITLE
[Fix] Some of the allowed tags is not working on email notifications set via Email Templates options

### DIFF
--- a/addons/email/class-helper.php
+++ b/addons/email/class-helper.php
@@ -90,7 +90,7 @@ class Helper {
 	public function __construct( $event, $args = array() ) {
 		$this->event = $event;
 
-		$this->args = wp_parse_args(
+		$this->args = ap_parse_args(
 			$args,
 			array(
 				'users'    => array(),

--- a/addons/email/email.php
+++ b/addons/email/email.php
@@ -588,6 +588,7 @@ class Email extends \AnsPress\Singleton {
 				'question_title' => $answer->post_title,
 				'answer_link'    => get_permalink( $answer->ID ),
 				'answer_content' => $answer->post_content,
+				'answer_excerpt' => ap_truncate_chars( wp_strip_all_tags( $answer->post_content ), 100 ),
 			)
 		);
 

--- a/admin/views/emails.php
+++ b/admin/views/emails.php
@@ -28,7 +28,7 @@ $i = 1;
 			<td>
 				<p>
 					<?php esc_attr_e( 'More email options can be found in addon options', 'anspress-question-answer' ); ?>
-					<a class="button" href="<?php echo esc_url( admin_url( 'admin.php?page=anspress_addons&active_addon=free%2Femail.php' ) ); ?>">
+					<a class="button" href="<?php echo esc_url( admin_url( 'admin.php?page=anspress_options&active_tab=features#features-email' ) ); ?>">
 						<?php esc_attr_e( 'More email options', 'anspress-question-answer' ); ?>
 					</a>
 				</p>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2504,7 +2504,7 @@ function ap_get_current_timestamp() {
  * @return array Merged user defined values with the default array.
  * @since 4.4.0
  */
-function ap_parse_args( array $args, array $defaults ) {
+function ap_parse_args( array $args, $defaults = array() ) {
 	$new_args = $defaults;
 
 	foreach ( $args as $key => $value ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2493,3 +2493,27 @@ function ap_get_current_timestamp() {
 
 	return $local_time->getTimestamp() + $local_time->getOffset();
 }
+
+/**
+ * Merges user defined array arguments into the defaults array,
+ * which works with arrays only.
+ *
+ * @param array $args     Value to be merged with the defaults array.
+ * @param array $defaults Array that serves as the defaults.
+ *
+ * @return array Merged user defined values with the default array.
+ * @since 4.4.0
+ */
+function ap_parse_args( $args, $defaults ) {
+	$new_args = (array) $defaults;
+
+	foreach ( $args as $key => $value ) {
+		if ( is_array( $value ) && isset( $new_args[ $key ] ) ) {
+			$new_args[ $key ] = ap_parse_args( $value, $new_args[ $key ] );
+		} else {
+			$new_args[ $key ] = $value;
+		}
+	}
+
+	return $new_args;
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2505,7 +2505,7 @@ function ap_get_current_timestamp() {
  * @since 4.4.0
  */
 function ap_parse_args( array $args, array $defaults ) {
-	$new_args = (array) $defaults;
+	$new_args = $defaults;
 
 	foreach ( $args as $key => $value ) {
 		if ( is_array( $value ) && isset( $new_args[ $key ] ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2504,7 +2504,7 @@ function ap_get_current_timestamp() {
  * @return array Merged user defined values with the default array.
  * @since 4.4.0
  */
-function ap_parse_args( $args, $defaults ) {
+function ap_parse_args( array $args, array $defaults ) {
 	$new_args = (array) $defaults;
 
 	foreach ( $args as $key => $value ) {


### PR DESCRIPTION
This PR includes:

* Fix the **{site_name}**, **{site_url}**, and **{site_description}** smart tags for email delivery change to required contents for **New Question**, **New Answer**, and **New Comment** email templates
* Fix the **{answer_excerpt}** smart tags for email delivery change to required contents for **Edit Answer** email templates
* Fix the **More email options** link available in the **Email Templates** option