### PR TITLE
[Fix] Fatal error: Uncaught Error: array_keys(): Argument #1 ($array) must be of type array

### DIFF
--- a/includes/common-pages.php
+++ b/includes/common-pages.php
@@ -206,7 +206,7 @@ class AnsPress_Common_Pages {
 	 */
 	public static function activities_page() {
 		$roles_exclude = ap_opt( 'activity_exclude_roles' );
-		$roles         = ! is_array( $roles_exclude ) ? array_keys( $roles_exclude ) : array();
+		$roles         = is_array( $roles_exclude ) ? array_keys( $roles_exclude ) : array();
 		$args          = array();
 
 		if ( ! empty( $roles ) ) {

--- a/includes/common-pages.php
+++ b/includes/common-pages.php
@@ -206,7 +206,7 @@ class AnsPress_Common_Pages {
 	 */
 	public static function activities_page() {
 		$roles_exclude = ap_opt( 'activity_exclude_roles' );
-		$roles         = ! empty( $roles_exclude ) ? array_keys( $roles_exclude ) : array();
+		$roles         = ! is_array( $roles_exclude ) ? array_keys( $roles_exclude ) : array();
 		$args          = array();
 
 		if ( ! empty( $roles ) ) {

--- a/includes/common-pages.php
+++ b/includes/common-pages.php
@@ -205,8 +205,9 @@ class AnsPress_Common_Pages {
 	 * @since 4.1.8 Added Exclude roles arguments.
 	 */
 	public static function activities_page() {
-		$roles = array_keys( ap_opt( 'activity_exclude_roles' ) );
-		$args  = array();
+		$roles_exclude = ap_opt( 'activity_exclude_roles' );
+		$roles         = ! empty( $roles_exclude ) ? array_keys( $roles_exclude ) : array();
+		$args          = array();
 
 		if ( ! empty( $roles ) ) {
 			$args['exclude_roles'] = $roles;


### PR DESCRIPTION
This PR includes:

* Fixes PHP fatal error for exclude roles case when selected any on of them available previously and later unselected/deselected all of them