### PR TITLE
[Fix] PHP Warning: Undefined array key image

### DIFF
--- a/addons/categories/categories.php
+++ b/addons/categories/categories.php
@@ -657,7 +657,7 @@ class Categories extends \AnsPress\Singleton {
 				$term_meta = array( 'image' => array() );
 			}
 
-			if ( ! is_array( $term_meta['image'] ) ) {
+			if ( isset( $term_meta['image'] ) && ! is_array( $term_meta['image'] ) ) {
 				$term_meta['image'] = array();
 			}
 


### PR DESCRIPTION
This PR includes:

* Fixes PHP warning being logged to error log file if **Question Categories** specific category has set either **Category icon class** or **Category icon color** but not **Image** option