### PR TITLE
[Fix] PHP warning message when using (AnsPress) Question Stats widget

### DIFF
--- a/includes/qaquery.php
+++ b/includes/qaquery.php
@@ -376,7 +376,7 @@ function ap_author_avatar( $size = 45, $_post = null ) {
  */
 function ap_get_answers_count( $_post = null ) {
 	$_post = ap_get_post( $_post );
-	if ( $_post ) {
+	if ( $_post && $_post->answers ) {
 		return (int) $_post->answers;
 	}
 	return null;

--- a/includes/qaquery.php
+++ b/includes/qaquery.php
@@ -372,14 +372,14 @@ function ap_author_avatar( $size = 45, $_post = null ) {
  * Return total published answer count.
  *
  * @param  mixed $_post Post ID, Object or null.
- * @return integer|null
+ * @return integer
  */
 function ap_get_answers_count( $_post = null ) {
 	$_post = ap_get_post( $_post );
 	if ( $_post && $_post->answers ) {
 		return (int) $_post->answers;
 	}
-	return null;
+	return 0;
 }
 
 /**

--- a/includes/qaquery.php
+++ b/includes/qaquery.php
@@ -504,7 +504,7 @@ function ap_recent_post_activity() {
  * Get last active time in human readable format.
  *
  * @param  mixed $post_id Post ID/Object.
- * @return string|null
+ * @return string
  * @since  2.4.8 Convert mysql date to GMT.
  */
 function ap_get_last_active( $post_id = null ) {
@@ -513,7 +513,7 @@ function ap_get_last_active( $post_id = null ) {
 		$date = ! empty( $p->last_updated ) ? $p->last_updated : $p->post_modified_gmt;
 		return ap_human_time( get_gmt_from_date( $date ), false );
 	}
-	return null;
+	return __( 'Invalid post', 'anspress-question-answer' );
 }
 
 /**

--- a/includes/qaquery.php
+++ b/includes/qaquery.php
@@ -372,11 +372,14 @@ function ap_author_avatar( $size = 45, $_post = null ) {
  * Return total published answer count.
  *
  * @param  mixed $_post Post ID, Object or null.
- * @return integer
+ * @return integer|null
  */
 function ap_get_answers_count( $_post = null ) {
 	$_post = ap_get_post( $_post );
-	return (int) $_post->answers;
+	if ( $_post ) {
+		return (int) $_post->answers;
+	}
+	return null;
 }
 
 /**
@@ -501,13 +504,16 @@ function ap_recent_post_activity() {
  * Get last active time in human readable format.
  *
  * @param  mixed $post_id Post ID/Object.
- * @return string
+ * @return string|null
  * @since  2.4.8 Convert mysql date to GMT.
  */
 function ap_get_last_active( $post_id = null ) {
-	$p    = ap_get_post( $post_id );
-	$date = ! empty( $p->last_updated ) ? $p->last_updated : $p->post_modified_gmt;
-	return ap_human_time( get_gmt_from_date( $date ), false );
+	$p = ap_get_post( $post_id );
+	if ( $p ) {
+		$date = ! empty( $p->last_updated ) ? $p->last_updated : $p->post_modified_gmt;
+		return ap_human_time( get_gmt_from_date( $date ), false );
+	}
+	return null;
 }
 
 /**


### PR DESCRIPTION
This PR includes:

* Fixes PHP Warning: Attempt to read property "answers" on bool when viewing non question page
* Fixes PHP Warning: Attempt to read property "post_modified_gmt" on bool when viewing non question page