### PR TITLE
[Fix] When a Question or an Answer is flagged then, in AnsPress main menu item, double the number shows as total count number required attention

### DIFF
--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -161,7 +161,7 @@ class AnsPress_Admin {
 			'flagged'  => $q_flagged->total + $a_flagged->total,
 		);
 
-		$types['total'] = array_sum( $types );
+		$types['total'] = $types['flagged'];
 		$types_html     = array();
 
 		foreach ( (array) $types as $k => $count ) {

--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -161,7 +161,7 @@ class AnsPress_Admin {
 			'flagged'  => $q_flagged->total + $a_flagged->total,
 		);
 
-		$types['total'] = $types['flagged'];
+		$types['total'] = (int) $types['flagged'];
 		$types_html     = array();
 
 		foreach ( (array) $types as $k => $count ) {


### PR DESCRIPTION
This PR includes:

* Fixes the total number of attention required for the **AnsPress** main menu item in the back end when a Question or an Answer is flagged by the user