### PR TITLE
[Fix] User profile page Answers tab Load more answers button does not hide even though all answers provided by the user is already loaded

### DIFF
--- a/addons/profile/profile.php
+++ b/addons/profile/profile.php
@@ -387,6 +387,9 @@ class Profile extends \AnsPress\Singleton {
 		}
 		$html = ob_get_clean();
 
+		// Pagination fix on Ajax load more event.
+		$paged = $answers->max_num_pages > $paged ? $paged : 0;
+
 		ap_ajax_json(
 			array(
 				'success' => true,


### PR DESCRIPTION
This PR includes:

* Fixes the **Load more answers** not hiding issue on the User Profile page Answers' tab even though all answers from the user is already loaded