### PR TITLE
[Fix] Show solved prefix plugin option not adding the [Solved] prefix before the question title

### DIFF
--- a/includes/class-theme.php
+++ b/includes/class-theme.php
@@ -166,6 +166,25 @@ class AnsPress_Theme {
 	}
 
 	/**
+	 * Filter document_title_parts.
+	 *
+	 * @param  array $title The document title parts.
+	 * @return array
+	 * @since 4.4.0
+	 */
+	public static function ap_title_parts( $title ) {
+		if ( is_anspress() ) {
+			remove_filter( 'document_title_parts', array( __CLASS__, 'ap_title_parts' ) );
+
+			if ( is_question() ) {
+				$title['title'] = ap_question_title_with_solved_prefix();
+			}
+		}
+
+		return $title;
+	}
+
+	/**
 	 * Add default before body sidebar in AnsPress contents
 	 */
 	public static function ap_before_html_body() {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -960,7 +960,7 @@ function ap_question_title_with_solved_prefix( $question_id = false ) {
 	$solved = ap_have_answer_selected( $question_id );
 
 	if ( ap_opt( 'show_solved_prefix' ) ) {
-		return get_the_title( $question_id ) . ' ' . ( $solved ? __( '[Solved] ', 'anspress-question-answer' ) : '' );
+		return ( $solved ? __( '[Solved] ', 'anspress-question-answer' ) : '' ) . get_the_title( $question_id ) . ' ';
 	}
 
 	return get_the_title( $question_id );

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -70,6 +70,7 @@ class AnsPress_Hooks {
 			anspress()->add_filter( 'body_class', 'AnsPress_Theme', 'body_class' );
 			anspress()->add_action( 'after_setup_theme', 'AnsPress_Theme', 'includes_theme' );
 			anspress()->add_filter( 'wp_title', 'AnsPress_Theme', 'ap_title', 0 );
+			anspress()->add_filter( 'document_title_parts', 'AnsPress_Theme', 'ap_title_parts', 0 );
 			anspress()->add_action( 'ap_before', 'AnsPress_Theme', 'ap_before_html_body' );
 			anspress()->add_action( 'wp_head', 'AnsPress_Theme', 'wp_head', 11 );
 			anspress()->add_action( 'ap_after_question_content', 'AnsPress_Theme', 'question_attachments', 11 );


### PR DESCRIPTION
This PR includes:

* Fixes to prefix question document title with **[Solved]** if **Show solved prefix** option is enabled