### PR TITLE
[Fix] Ask form category order plugin option not working

### DIFF
--- a/lib/form/class-select.php
+++ b/lib/form/class-select.php
@@ -45,6 +45,7 @@ class Select extends \AnsPress\Form\Field {
 					'taxonomy'   => 'question_category',
 					'hide_empty' => false,
 					'fields'     => 'id=>name',
+					'orderby'    => ap_opt( 'form_category_orderby' ),
 				),
 			)
 		);


### PR DESCRIPTION
This PR includes:

* Fixes the ask form category order option modifying the display order of category select option in the ask form