### PR TITLE
[Fix] OP can answer? plugin option is working in opposite way

### DIFF
--- a/includes/class/roles-cap.php
+++ b/includes/class/roles-cap.php
@@ -216,7 +216,7 @@ function ap_user_can_answer( $question_id, $user_id = false ) {
 	}
 
 	// Check if user is original poster and dont allow them to answer their own question.
-	if ( is_user_logged_in() && ! ap_opt( 'disallow_op_to_answer' ) && ! empty( $question->post_author ) && $question->post_author == $user_id ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+	if ( is_user_logged_in() && ap_opt( 'disallow_op_to_answer' ) && ! empty( $question->post_author ) && $question->post_author == $user_id ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 		return false;
 	}
 


### PR DESCRIPTION
This PR includes:

* Fixes the **OP can answer?** plugin option working in opposite way