### PR TITLE
[Fix] Plugin activate on fresh WordPress install generates PHP error(warning) messages

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -71,8 +71,6 @@ class AP_Activate {
 		$this->network_wide = $network_wide;
 		$this->disable_ext();
 		$this->delete_options();
-		$this->enable_addons();
-		$this->reactivate_addons();
 
 		// Append table names in $wpdb.
 		ap_append_table_names();
@@ -82,6 +80,10 @@ class AP_Activate {
 		} else {
 			$this->activate();
 		}
+
+		// Enable/Disable addon.
+		$this->enable_addons();
+		$this->reactivate_addons();
 	}
 
 	/**


### PR DESCRIPTION
This PR includes:

* Fixes PHP error(warning) messages being logged into debug log file if WordPress debug log is enabled and plugin is activated for the first time