### PR TITLE
[Fix] Default plugin features(addons) activated automatically on plugin activation

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -125,8 +125,8 @@ class AP_Activate {
 	 * @since 4.1.8 Fixed #425
 	 */
 	public function enable_addons() {
-		// Return if `anspress_installed` plugin option is available.
-		if ( ap_opt( 'anspress_installed' ) ) {
+		// Return if `ap_installed` option is available.
+		if ( ap_opt( 'ap_installed' ) ) {
 			return;
 		}
 
@@ -134,9 +134,6 @@ class AP_Activate {
 		ap_activate_addon( 'reputation.php' );
 		ap_activate_addon( 'email.php' );
 		ap_activate_addon( 'categories.php' );
-
-		// Update plugin option with `anspress_installed` for setting a flag.
-		ap_opt( 'anspress_installed', 'true' );
 	}
 
 	/**

--- a/activate.php
+++ b/activate.php
@@ -125,9 +125,18 @@ class AP_Activate {
 	 * @since 4.1.8 Fixed #425
 	 */
 	public function enable_addons() {
+		// Return if `anspress_installed` plugin option is available.
+		if ( ap_opt( 'anspress_installed' ) ) {
+			return;
+		}
+
+		// Activate required addons.
 		ap_activate_addon( 'reputation.php' );
 		ap_activate_addon( 'email.php' );
 		ap_activate_addon( 'categories.php' );
+
+		// Update plugin option with `anspress_installed` for setting a flag.
+		ap_opt( 'anspress_installed', 'true' );
 	}
 
 	/**


### PR DESCRIPTION
This PR includes:

* Fixes default features(addons) enabled automatically on plugin activation although already disabled by the user