### PR TITLE
[Fix] Post status updated successfully Ajax message on question and answer status changes

### DIFF
--- a/includes/post-status.php
+++ b/includes/post-status.php
@@ -90,7 +90,13 @@ class AnsPress_Post_Status {
 		ap_ajax_json(
 			array(
 				'success'     => true,
-				'snackbar'    => array( 'message' => __( 'Post status updated successfully', 'anspress-question-answer' ) ),
+				'snackbar'    => array(
+					'message' => sprintf(
+						/* Translators: %s Question or Answer post type label for post status change */
+						__( '%s status updated successfully', 'anspress-question-answer' ),
+						( 'question' === $post->post_type ) ? esc_html__( 'Question', 'anspress-question-answer' ) : esc_html__( 'Answer', 'anspress-question-answer' )
+					),
+				),
 				'action'      => array( 'active' => true ),
 				'postmessage' => ap_get_post_status_message( $post->ID ),
 				'newStatus'   => $status,


### PR DESCRIPTION
This PR includes:

* Modify the Ajax message for post status change on Question and Answer post type from the front end