### PR TITLE
[Fix] Flagged question and answer Ajax message

### DIFF
--- a/includes/flag.php
+++ b/includes/flag.php
@@ -30,6 +30,7 @@ class AnsPress_Flag {
 			ap_ajax_json( 'something_wrong' );
 		}
 
+		$post       = ap_get_post( $post_id );
 		$userid     = get_current_user_id();
 		$is_flagged = ap_is_user_flagged( $post_id );
 
@@ -38,7 +39,13 @@ class AnsPress_Flag {
 			ap_ajax_json(
 				array(
 					'success'  => false,
-					'snackbar' => array( 'message' => __( 'You have already reported this post.', 'anspress-question-answer' ) ),
+					'snackbar' => array(
+						'message' => sprintf(
+							/* Translators: %s Question or Answer post type label for already reported question or answer. */
+							__( 'You have already reported this %s.', 'anspress-question-answer' ),
+							( 'question' === $post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+						),
+					),
 				)
 			);
 		}
@@ -53,7 +60,13 @@ class AnsPress_Flag {
 					'count'  => $count,
 					'active' => true,
 				),
-				'snackbar' => array( 'message' => __( 'Thank you for reporting this post.', 'anspress-question-answer' ) ),
+				'snackbar' => array(
+					'message' => sprintf(
+						/* Translators: %s Question or Answer post type label for reported question or answer. */
+						__( 'Thank you for reporting this %s.', 'anspress-question-answer' ),
+						( 'question' === $post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+					),
+				),
 			)
 		);
 	}


### PR DESCRIPTION
This PR includes:

* Modify the Ajax message for flagging either a question or an answer by the logged in user from the front end