### PR TITLE
[Fix] Question and Answer action links title

### DIFF
--- a/includes/ajax-hooks.php
+++ b/includes/ajax-hooks.php
@@ -175,7 +175,11 @@ class AnsPress_Ajax {
 					'action'      => array(
 						'active' => false,
 						'label'  => __( 'Delete', 'anspress-question-answer' ),
-						'title'  => __( 'Delete this post (can be restored again)', 'anspress-question-answer' ),
+						'title'  => sprintf(
+							/* Translators: %s Question or Answer post type label for deleting a question or answer. */
+							__( 'Delete this %s (can be restored again)', 'anspress-question-answer' ),
+							( 'question' === $post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+						),
 					),
 					// translators: %s post type.
 					'snackbar'    => array( 'message' => sprintf( __( '%s is restored', 'anspress-question-answer' ), $post_type ) ),
@@ -209,7 +213,11 @@ class AnsPress_Ajax {
 				'action'      => array(
 					'active' => true,
 					'label'  => __( 'Undelete', 'anspress-question-answer' ),
-					'title'  => __( 'Restore this post', 'anspress-question-answer' ),
+					'title'  => sprintf(
+						/* Translators: %s Question or Answer post type label for restoring a question or answer. */
+						__( 'Restore this %s', 'anspress-question-answer' ),
+						( 'question' === $post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+					),
 				),
 				// translators: %s is post type.
 				'snackbar'    => array( 'message' => sprintf( __( '%s is trashed', 'anspress-question-answer' ), $post_type ) ),

--- a/includes/flag.php
+++ b/includes/flag.php
@@ -129,7 +129,19 @@ function ap_flag_btn_args( $post = null ) {
 	$_post   = ap_get_post( $post );
 	$flagged = ap_is_user_flagged( $_post );
 
-	$title = ( ! $flagged ) ? ( __( 'Flag this post', 'anspress-question-answer' ) ) : ( __( 'You have flagged this post', 'anspress-question-answer' ) );
+	if ( ! $flagged ) {
+		$title = sprintf(
+			/* Translators: %s Question or Answer post type label for flagging question or answer. */
+			__( 'Flag this %s', 'anspress-question-answer' ),
+			( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+		);
+	} else {
+		$title = sprintf(
+			/* Translators: %s Question or Answer post type label for already flagged question or answer. */
+			__( 'You have flagged this %s', 'anspress-question-answer' ),
+			( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+		);
+	}
 
 	$actions['close'] = array(
 		'cb'     => 'flag',

--- a/includes/theme.php
+++ b/includes/theme.php
@@ -292,10 +292,18 @@ function ap_post_actions( $_post = null ) {
 	if ( ap_user_can_delete_post( $_post->ID ) ) {
 		if ( 'trash' === $_post->post_status ) {
 			$label = __( 'Undelete', 'anspress-question-answer' );
-			$title = __( 'Restore this post', 'anspress-question-answer' );
+			$title = sprintf(
+				/* Translators: %s Question or Answer post type label for restoring a question or answer. */
+				__( 'Restore this %s', 'anspress-question-answer' ),
+				( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+			);
 		} else {
 			$label = __( 'Delete', 'anspress-question-answer' );
-			$title = __( 'Delete this post (can be restored again)', 'anspress-question-answer' );
+			$title = sprintf(
+				/* Translators: %s Question or Answer post type label for deleting a question or answer. */
+				__( 'Delete this %s (can be restored again)', 'anspress-question-answer' ),
+				( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+			);
 		}
 
 		$actions[] = array(
@@ -318,7 +326,11 @@ function ap_post_actions( $_post = null ) {
 				'__nonce' => wp_create_nonce( 'delete_post_' . $_post->ID ),
 			),
 			'label' => __( 'Delete Permanently', 'anspress-question-answer' ),
-			'title' => __( 'Delete post permanently (cannot be restored again)', 'anspress-question-answer' ),
+			'title' => sprintf(
+				/* Translators: %s Question or Answer post type label for permanently deleting a question or answer. */
+				__( 'Delete %s permanently (cannot be restored again)', 'anspress-question-answer' ),
+				( 'question' === $_post->post_type ) ? esc_html__( 'question', 'anspress-question-answer' ) : esc_html__( 'answer', 'anspress-question-answer' )
+			),
 		);
 	}
 


### PR DESCRIPTION
This PR includes:

* Modify the post action links title for **Flag this post**, **Delete this post (can be restored again)**, and **Delete post permanently (cannot be restored again)** to render the respective Question or Answer post type label instead of showing post