### PR TITLE
[Fix] Notifications page Seen filter displays the Mark all as seen button

### DIFF
--- a/templates/addons/notification/index.php
+++ b/templates/addons/notification/index.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $user_id = get_query_var( 'ap_user_id' );
 ?>
 
-<?php if ( ap_count_unseen_notifications() > 0 ) : ?>
+<?php if ( ap_count_unseen_notifications() > 0 && ( ! isset( $_GET['seen'] ) || ( '1' !== $_GET['seen'] ) ) ) : ?>
 	<?php
 		$btn_args = wp_json_encode(
 			array(


### PR DESCRIPTION
This PR includes:

* Fixes the **Mark all as seen** button display on notification page on the required notifications tab/links only