### PR TITLE
[Fix] User registration is done even though WordPress Membership option is disabled

### DIFF
--- a/includes/class-form-hooks.php
+++ b/includes/class-form-hooks.php
@@ -84,13 +84,13 @@ class AP_Form_Hooks {
 				'max_length' => 64,
 			);
 
-			if ( empty( $editing_id ) && ap_opt( 'create_account' ) ) {
+			if ( empty( $editing_id ) && ap_opt( 'create_account' ) && get_option( 'users_can_register' ) ) {
 				$form['fields']['email'] = array(
 					'label'      => __( 'Your Email', 'anspress-question-answer' ),
 					'attr'       => array(
 						'placeholder' => __( 'Enter your email', 'anspress-question-answer' ),
 					),
-					'desc'       => 'An account for you will be created and a confirmation link will be sent to you with the password.',
+					'desc'       => __( 'An account for you will be created and a confirmation link will be sent to you with the password.', 'anspress-question-answer' ),
 					'order'      => 20,
 					'validate'   => 'is_email,required',
 					'sanitize'   => 'email,required',
@@ -198,13 +198,13 @@ class AP_Form_Hooks {
 				'max_length' => 20,
 			);
 
-			if ( empty( $editing_id ) && ap_opt( 'create_account' ) ) {
+			if ( empty( $editing_id ) && ap_opt( 'create_account' ) && get_option( 'users_can_register' ) ) {
 				$form['fields']['email'] = array(
 					'label'      => __( 'Your Email', 'anspress-question-answer' ),
 					'attr'       => array(
 						'placeholder' => __( 'Enter your email', 'anspress-question-answer' ),
 					),
-					'desc'       => 'An account for you will be created and a confirmation link will be sent to you with the password.',
+					'desc'       => __( 'An account for you will be created and a confirmation link will be sent to you with the password.', 'anspress-question-answer' ),
 					'order'      => 20,
 					'validate'   => 'is_email,required',
 					'sanitize'   => 'email,required',
@@ -399,7 +399,7 @@ class AP_Form_Hooks {
 		}
 
 		// Create user if enabled.
-		if ( ! $editing && ! is_user_logged_in() && ap_opt( 'create_account' ) ) {
+		if ( ! $editing && ! is_user_logged_in() && ap_opt( 'create_account' ) && get_option( 'users_can_register' ) ) {
 			self::create_user( $values, $question_args, $manual );
 		}
 
@@ -623,7 +623,7 @@ class AP_Form_Hooks {
 		}
 
 		// Create user if enabled.
-		if ( ! $editing && ! is_user_logged_in() && ap_opt( 'create_account' ) ) {
+		if ( ! $editing && ! is_user_logged_in() && ap_opt( 'create_account' ) && get_option( 'users_can_register' ) ) {
 			self::create_user( $values, $answer_args, $manual );
 		}
 

--- a/templates/login-signup.php
+++ b/templates/login-signup.php
@@ -20,8 +20,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 
 		<div class="ap-login-buttons">
-			<a href="<?php echo esc_url( wp_registration_url() ); ?>"><?php esc_attr_e( 'Register', 'anspress-question-answer' ); ?></a>
-			<span class="ap-login-sep"><?php esc_attr_e( 'or', 'anspress-question-answer' ); ?></span>
+			<?php if ( get_option( 'users_can_register' ) ) { ?>
+				<a href="<?php echo esc_url( wp_registration_url() ); ?>"><?php esc_attr_e( 'Register', 'anspress-question-answer' ); ?></a>
+				<span class="ap-login-sep"><?php esc_attr_e( 'or', 'anspress-question-answer' ); ?></span>
+			<?php } ?>
+
 			<a href="<?php echo esc_url( wp_login_url( get_the_permalink() ) ); ?>"><?php esc_attr_e( 'Login', 'anspress-question-answer' ); ?></a>
 		</div>
 	</div>


### PR DESCRIPTION
This PR includes:

* Fixes the user registration done on posting a question or an answer even though WordPress **Membership** option is disabled