### PR TITLE
[Fix] Warning: Attempt to read property post_author on null

### DIFF
--- a/addons/notifications/notifications.php
+++ b/addons/notifications/notifications.php
@@ -274,16 +274,18 @@ class Notifications extends \AnsPress\Singleton {
 	 */
 	public function new_answer( $post_id, $_post ) {
 		$_question = get_post( $_post->post_parent );
-		ap_insert_notification(
-			array(
-				'user_id'  => $_question->post_author,
-				'actor'    => $_post->post_author,
-				'parent'   => $_post->post_parent,
-				'ref_id'   => $_post->ID,
-				'ref_type' => 'answer',
-				'verb'     => 'new_answer',
-			)
-		);
+		if ( $_question ) {
+			ap_insert_notification(
+				array(
+					'user_id'  => $_question->post_author,
+					'actor'    => $_post->post_author,
+					'parent'   => $_post->post_parent,
+					'ref_id'   => $_post->ID,
+					'ref_type' => 'answer',
+					'verb'     => 'new_answer',
+				)
+			);
+		}
 	}
 
 	/**

--- a/addons/notifications/notifications.php
+++ b/addons/notifications/notifications.php
@@ -274,18 +274,23 @@ class Notifications extends \AnsPress\Singleton {
 	 */
 	public function new_answer( $post_id, $_post ) {
 		$_question = get_post( $_post->post_parent );
-		if ( $_question ) {
-			ap_insert_notification(
-				array(
-					'user_id'  => $_question->post_author,
-					'actor'    => $_post->post_author,
-					'parent'   => $_post->post_parent,
-					'ref_id'   => $_post->ID,
-					'ref_type' => 'answer',
-					'verb'     => 'new_answer',
-				)
-			);
+
+		// Return if question is not available.
+		if ( ! $_question ) {
+			return;
 		}
+
+		// Insert the notification.
+		ap_insert_notification(
+			array(
+				'user_id'  => $_question->post_author,
+				'actor'    => $_post->post_author,
+				'parent'   => $_post->post_parent,
+				'ref_id'   => $_post->ID,
+				'ref_type' => 'answer',
+				'verb'     => 'new_answer',
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR includes:

* Fixes PHP warning message being logged into the debug log file when notification addon is enabled and adding answer to a question from back end if WordPress debug log is enabled