### PR TITLE
[Fix] Syntax Highlighter addon is not working when Quick tags editor is enabled 

### DIFF
--- a/addons/syntaxhighlighter/script.js
+++ b/addons/syntaxhighlighter/script.js
@@ -67,7 +67,10 @@ SyntaxHighlighter.all();
 
 			var code = $(this).find('textarea').val();
 			code = code.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
-			code = tinyMCE.DOM.encode(code).replace(/^[\s]+/gm, function (m) {
+			if ( typeof tinymce !== 'undefined' ) {
+				code = tinyMCE.DOM.encode(code);
+			}
+			code = code.replace(/^[\s]+/gm, function (m) {
 				var leadingSpaces = arguments[0].length;
 				var str = '';
 				while (leadingSpaces > 0) {
@@ -84,7 +87,7 @@ SyntaxHighlighter.all();
 			var attr = 'language="' + lang + '"';
 			var cont = '[apcode ' + attr + ']<' + tag + ' data-mce-contenteditable="false">' + code + '</' + tag + '>[/apcode]';
 
-			if ( tinyMCE.activeEditor !== null ) {
+			if ( typeof tinymce !== 'undefined' ) {
 				tinymce.activeEditor.insertContent(cont);
 				tinymce.activeEditor.focus();
 				tinymce.activeEditor.selection.collapse(0);

--- a/addons/syntaxhighlighter/script.js
+++ b/addons/syntaxhighlighter/script.js
@@ -83,15 +83,28 @@ SyntaxHighlighter.all();
 
 			var attr = 'language="' + lang + '"';
 			var cont = '[apcode ' + attr + ']<' + tag + ' data-mce-contenteditable="false">' + code + '</' + tag + '>[/apcode]';
-			tinymce.activeEditor.insertContent(cont);
-			tinymce.activeEditor.focus();
-			tinymce.activeEditor.selection.collapse(0);
+
+			if ( tinyMCE.activeEditor !== null ) {
+				tinymce.activeEditor.insertContent(cont);
+				tinymce.activeEditor.focus();
+				tinymce.activeEditor.selection.collapse(0);
+			} else {
+				var elem = $( '.ap-editor .wp-editor-area' );
+				var value = elem.val();
+				var start = elem[0].selectionStart;
+				var end = elem[0].selectionEnd;
+				var before = value.substring( 0, start );
+				var after = value.substring( end, value.length );
+				var cursorPos = elem.prop( 'selectionStart' );
+				elem.val( before + cont + after );
+				elem.focus();
+				elem.prop( 'selectionEnd', cursorPos + cont.length );
+			}
+
 			AnsPress.hideModal('code');
 
 			return false;
 		});
-
-
 
 	});
 

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -516,13 +516,13 @@ _.templateSettings = {
 			$('<img class="ap-img-preview" src="' + src + '" />').appendTo(el);
 		},
 		imageUploaded: function (data) {
-			if (data.action !== 'ap_image_upload' || typeof tinymce === 'undefined')
+			if (data.action !== 'ap_image_upload')
 				return;
 
 			if (data.files)
 				$.each(data.files, function (old, newFile) {
 					var cont = '<img src="' + newFile + '" />';
-					if ( tinyMCE.activeEditor !== null ) {
+					if ( typeof tinymce !== 'undefined' ) {
 						tinymce.activeEditor.insertContent(cont);
 					} else {
 						var elem = $( '.ap-editor .wp-editor-area' );

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -521,7 +521,21 @@ _.templateSettings = {
 
 			if (data.files)
 				$.each(data.files, function (old, newFile) {
-					tinymce.activeEditor.insertContent('<img src="' + newFile + '" />');
+					var cont = '<img src="' + newFile + '" />';
+					if ( tinyMCE.activeEditor !== null ) {
+						tinymce.activeEditor.insertContent(cont);
+					} else {
+						var elem = $( '.ap-editor .wp-editor-area' );
+						var value = elem.val();
+						var start = elem[0].selectionStart;
+						var end = elem[0].selectionEnd;
+						var before = value.substring( 0, start );
+						var after = value.substring( end, value.length );
+						var cursorPos = elem.prop( 'selectionStart' );
+						elem.val( before + cont + after );
+						elem.focus();
+						elem.prop( 'selectionEnd', cursorPos + cont.length );
+					}
 				});
 
 			AnsPress.hideModal('imageUpload');

--- a/templates/functions.php
+++ b/templates/functions.php
@@ -37,6 +37,11 @@ function ap_scripts_front() {
 
 	wp_enqueue_style( 'ap-overrides', ap_get_theme_url( 'css/overrides.css' ), array( 'anspress-main' ), AP_VERSION );
 
+	// Enqueue the TinyMCE JavaScript library file.
+	if ( ap_opt( 'question_text_editor' ) || ap_opt( 'answer_text_editor' ) ) {
+		wp_enqueue_script( 'wp-tinymce' );
+	}
+
 	$aplang = array(
 		'loading'                => __( 'Loading..', 'anspress-question-answer' ),
 		'sending'                => __( 'Sending request', 'anspress-question-answer' ),

--- a/templates/functions.php
+++ b/templates/functions.php
@@ -37,11 +37,6 @@ function ap_scripts_front() {
 
 	wp_enqueue_style( 'ap-overrides', ap_get_theme_url( 'css/overrides.css' ), array( 'anspress-main' ), AP_VERSION );
 
-	// Enqueue the TinyMCE JavaScript library file.
-	if ( ap_opt( 'question_text_editor' ) || ap_opt( 'answer_text_editor' ) ) {
-		wp_enqueue_script( 'wp-tinymce' );
-	}
-
 	$aplang = array(
 		'loading'                => __( 'Loading..', 'anspress-question-answer' ),
 		'sending'                => __( 'Sending request', 'anspress-question-answer' ),


### PR DESCRIPTION
This PR includes:

* Fixes the **Syntax Highlighter** addon/feature not working when Quick tags editor is enabled for Question and Answer