### PR TITLE
[Fix] Max upload size plugin option can exceed the value to be set inside it more than max_upload_size php.ini settings

### DIFF
--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -76,7 +76,6 @@ class AnsPress_Admin {
 		anspress()->add_action( 'admin_action_ap_addon_options', __CLASS__, 'ap_addon_options' );
 		anspress()->add_action( 'admin_action_ap_save_addon_options', __CLASS__, 'save_addon_options' );
 		anspress()->add_action( 'admin_footer', __CLASS__, 'admin_footer' );
-		anspress()->add_filter( 'anspress_opt_modify_before_update', __CLASS__, 'anspress_opt_modify_before_update', 10, 2 );
 	}
 
 	/**
@@ -1530,31 +1529,5 @@ class AnsPress_Admin {
 				}
 			</style>
 		<?php
-	}
-
-	/**
-	 * Modify the AnsPress options data before the
-	 * actual AnsPress options data is modified
-	 * for the save event.
-	 *
-	 * @param string $key Option key.
-	 * @param array  $opt Option value.
-	 */
-	public static function anspress_opt_modify_before_update( $key, $opt ) {
-		// Modify the max_upload_size options data to not
-		// exceed the value set in php.ini config.
-		if ( 'max_upload_size' === $key ) {
-			$max_upload = wp_max_upload_size();
-			if ( $opt['value'] > $max_upload ) {
-				$opt['value'] = (int) $max_upload;
-			} else {
-				$opt['value'] = (int) $opt['value'];
-			}
-		}
-
-		return array(
-			'key' => $key,
-			'opt' => $opt,
-		);
 	}
 }

--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -76,6 +76,7 @@ class AnsPress_Admin {
 		anspress()->add_action( 'admin_action_ap_addon_options', __CLASS__, 'ap_addon_options' );
 		anspress()->add_action( 'admin_action_ap_save_addon_options', __CLASS__, 'save_addon_options' );
 		anspress()->add_action( 'admin_footer', __CLASS__, 'admin_footer' );
+		anspress()->add_filter( 'anspress_opt_modify_before_update', __CLASS__, 'anspress_opt_modify_before_update', 10, 2 );
 	}
 
 	/**
@@ -1168,7 +1169,7 @@ class AnsPress_Admin {
 				),
 				'max_upload_size'     => array(
 					'label' => __( 'Max upload size', 'anspress-question-answer' ),
-					'desc'  => __( 'Set maximum upload size.', 'anspress-question-answer' ),
+					'desc'  => __( 'Set maximum upload size in bytes.', 'anspress-question-answer' ),
 					'value' => $opt['max_upload_size'],
 				),
 				'allow_private_posts' => array(
@@ -1529,5 +1530,31 @@ class AnsPress_Admin {
 				}
 			</style>
 		<?php
+	}
+
+	/**
+	 * Modify the AnsPress options data before the
+	 * actual AnsPress options data is modified
+	 * for the save event.
+	 *
+	 * @param string $key Option key.
+	 * @param array  $opt Option value.
+	 */
+	public static function anspress_opt_modify_before_update( $key, $opt ) {
+		// Modify the max_upload_size options data to not
+		// exceed the value set in php.ini config.
+		if ( 'max_upload_size' === $key ) {
+			$max_upload = wp_max_upload_size();
+			if ( $opt['value'] > $max_upload ) {
+				$opt['value'] = (int) $max_upload;
+			} else {
+				$opt['value'] = (int) $opt['value'];
+			}
+		}
+
+		return array(
+			'key' => $key,
+			'opt' => $opt,
+		);
 	}
 }

--- a/admin/views/options.php
+++ b/admin/views/options.php
@@ -124,7 +124,17 @@ if ( ! empty( $form_name ) && anspress()->get_form( $form_name )->is_submitted()
 		$options = get_option( 'anspress_opt', array() );
 
 		foreach ( $values as $key => $opt ) {
-			$options[ $key ] = $opt['value'];
+			/**
+			 * Modify the AnsPress options data before the
+			 * actual AnsPress options data is modified
+			 * for the save event.
+			 *
+			 * @param string $key Option key.
+			 * @param array  $opt Option value.
+			 */
+			$filtered = apply_filters( 'anspress_opt_modify_before_update', $key, $opt );
+
+			$options[ $filtered['key'] ] = $filtered['opt']['value'];
 		}
 
 		update_option( 'anspress_opt', $options );

--- a/admin/views/options.php
+++ b/admin/views/options.php
@@ -124,17 +124,7 @@ if ( ! empty( $form_name ) && anspress()->get_form( $form_name )->is_submitted()
 		$options = get_option( 'anspress_opt', array() );
 
 		foreach ( $values as $key => $opt ) {
-			/**
-			 * Modify the AnsPress options data before the
-			 * actual AnsPress options data is modified
-			 * for the save event.
-			 *
-			 * @param string $key Option key.
-			 * @param array  $opt Option value.
-			 */
-			$filtered = apply_filters( 'anspress_opt_modify_before_update', $key, $opt );
-
-			$options[ $filtered['key'] ] = $filtered['opt']['value'];
+			$options[ $key ] = $opt['value'];
 		}
 
 		update_option( 'anspress_opt', $options );

--- a/admin/views/options.php
+++ b/admin/views/options.php
@@ -124,6 +124,16 @@ if ( ! empty( $form_name ) && anspress()->get_form( $form_name )->is_submitted()
 		$options = get_option( 'anspress_opt', array() );
 
 		foreach ( $values as $key => $opt ) {
+			// Modify the max_upload_size options data to not
+			// exceed the value set in php.ini config.
+			if ( 'max_upload_size' === $key ) {
+				$max_upload = wp_max_upload_size();
+				if ( $opt['value'] > $max_upload ) {
+					$opt['value'] = (int) $max_upload;
+				} else {
+					$opt['value'] = (int) $opt['value'];
+				}
+			}
 			$options[ $key ] = $opt['value'];
 		}
 


### PR DESCRIPTION
This PR includes:

* Fixes the **Max upload size** plugin option value to not exceed the value set in **max_upload_size php.ini** configuration file