### PR TITLE
[Fix] Attempt to read property name on bool

### DIFF
--- a/addons/tags/tags.php
+++ b/addons/tags/tags.php
@@ -444,7 +444,10 @@ class Tags extends \AnsPress\Singleton {
 		} elseif ( is_question_tag() ) {
 			$tag_id = sanitize_title( get_query_var( 'q_tag' ) );
 			$tag    = $tag_id ? get_term_by( 'slug', $tag_id, 'question_tag' ) : get_queried_object();
-			$title  = $tag->name;
+
+			if ( $tag ) {
+				$title = $tag->name;
+			}
 		}
 
 		return $title;

--- a/addons/tags/tags.php
+++ b/addons/tags/tags.php
@@ -443,7 +443,7 @@ class Tags extends \AnsPress\Singleton {
 			$title = ap_opt( 'tags_page_title' );
 		} elseif ( is_question_tag() ) {
 			$tag_id = sanitize_title( get_query_var( 'q_tag' ) );
-			$tag = get_term_by( 'slug', $tag_id, 'question_tag' ); // @codingStandardsIgnoreLine.
+			$tag    = $tag_id ? get_term_by( 'slug', $tag_id, 'question_tag' ) : get_queried_object();
 			$title  = $tag->name;
 		}
 
@@ -459,7 +459,7 @@ class Tags extends \AnsPress\Singleton {
 	public function ap_breadcrumbs( $navs ) {
 		if ( is_question_tag() ) {
 			$tag_id       = sanitize_title( get_query_var( 'q_tag' ) );
-			$tag = get_term_by( 'slug', $tag_id, 'question_tag' ); // @codingStandardsIgnoreLine.
+			$tag          = $tag_id ? get_term_by( 'slug', $tag_id, 'question_tag' ) : get_queried_object();
 			$navs['page'] = array(
 				'title' => __( 'Tags', 'anspress-question-answer' ),
 				'link'  => ap_get_link_to( 'tags' ),

--- a/includes/taxo.php
+++ b/includes/taxo.php
@@ -431,7 +431,7 @@ function ap_question_have_tags( $question_id = false ) {
  * @return bool
  */
 function is_question_tag() {
-	if ( ap_get_tag_slug() === get_query_var( 'ap_page' ) ) {
+	if ( 'tag' === ap_current_page() ) {
 		return true;
 	}
 
@@ -444,7 +444,7 @@ function is_question_tag() {
  * @return bool
  */
 function is_question_tags() {
-	if ( ap_get_tags_slug() === get_query_var( 'ap_page' ) ) {
+	if ( 'tags' === ap_current_page() ) {
 		return true;
 	}
 


### PR DESCRIPTION
This PR includes:

* PHP warning to be logged into debug log file if **(AnsPress) Breadcrumbs** widget is used in the **(AnsPress) Question List** Top widgetized area and viewing the individual tag page
* Fixes the display of the single tag item in the single tag page and Tags item in the tags archive page for the **(AnsPress) Breadcrumbs** widget
* Fixes the condition to check for currently viewing page is either a tag page or tags archive page