### PR TITLE
[Fix] Improper description for Font icon class, if image not set category option

### DIFF
--- a/addons/categories/categories.php
+++ b/addons/categories/categories.php
@@ -557,7 +557,23 @@ class Categories extends \AnsPress\Singleton {
 		<div class='form-field term-image-wrap'>
 			<label for='ap_icon'><?php esc_attr_e( 'Category icon class', 'anspress-question-answer' ); ?></label>
 			<input id="ap_icon" type="text" name="ap_icon" value="">
-			<p class="description"><?php esc_attr_e( 'Font icon class, if image not set', 'anspress-question-answer' ); ?></p>
+			<p class="description">
+				<?php
+				echo wp_kses(
+					sprintf(
+						/* translators: %s Link to font icon class. */
+						__( 'Font icon class, if image not set. Find our official list of icons from <a href="%s" target="_blank">here</a>.', 'anspress-question-answer' ),
+						esc_url( 'https://htmlpreview.github.io/?https://github.com/anspress/anspress/blob/3.0.7/theme/default/fonts/demo.html' )
+					),
+					array(
+						'a' => array(
+							'href'   => array(),
+							'target' => array(),
+						),
+					)
+				);
+				?>
+			</p>
 		</div>
 
 		<div class='form-field term-image-wrap'>
@@ -618,16 +634,32 @@ class Categories extends \AnsPress\Singleton {
 				</th>
 				<td>
 					<input id="ap_icon" type="text" name="ap_icon" value="<?php echo esc_attr( $term_meta['icon'] ); ?>">
-					<p class="description"><?php esc_attr_e( 'Font icon class, if image not set', 'anspress-question-answer' ); ?></p>
+					<p class="description">
+						<?php
+						echo wp_kses(
+							sprintf(
+								/* translators: %s Link to font icon class. */
+								__( 'Font icon class, if image not set. Find our official list of icons from <a href="%s" target="_blank">here</a>.', 'anspress-question-answer' ),
+								esc_url( 'https://htmlpreview.github.io/?https://github.com/anspress/anspress/blob/3.0.7/theme/default/fonts/demo.html' )
+							),
+							array(
+								'a' => array(
+									'href'   => array(),
+									'target' => array(),
+								),
+							)
+						);
+						?>
+					</p>
 				</td>
 			</tr>
 			<tr class='form-field term-name-wrap'>
 				<th scope='row'>
-					<label for='ap-category-color'><?php esc_attr_e( 'Category icon color', 'anspress-question-answer' ); ?></label>
+					<label for='ap-category-color'><?php esc_attr_e( 'Icon background color', 'anspress-question-answer' ); ?></label>
 				</th>
 				<td>
 					<input id="ap-category-color" type="text" name="ap_color" value="<?php echo esc_attr( $term_meta['color'] ); ?>">
-					<p class="description"><?php esc_attr_e( 'Font icon class, if image not set', 'anspress-question-answer' ); ?></p>
+					<p class="description"><?php esc_attr_e( 'Set background color to be used with icon', 'anspress-question-answer' ); ?></p>
 					<script type="text/javascript">
 						jQuery(document).ready(function(){
 							jQuery('#ap-category-color').wpColorPicker();


### PR DESCRIPTION
This PR includes:

* Modifies the **Font icon class, if image not set** string to include url to the icon classes which can be used
* Fixes **Category icon color** title and description on question category edit page