### PR TITLE
[Fix] PHP Deprecated message regarding BuddyPress addon

### DIFF
--- a/addons/buddypress/buddypress.php
+++ b/addons/buddypress/buddypress.php
@@ -428,7 +428,7 @@ class BuddyPress extends \AnsPress\Singleton {
 	 *
 	 * @since 4.1.8
 	 */
-	public function notifications_for_user( $action, $item_id, $secondary_item_id, $total_items, $format = 'string', $component_action_name, $component_name, $id ) {
+	public function notifications_for_user( $action, $item_id, $secondary_item_id, $total_items, $format = 'string', $component_action_name = '', $component_name = '', $id = '' ) {
 		if ( method_exists( $this, 'notification_' . $component_action_name ) ) {
 			$method = 'notification_' . $action;
 			return $this->$method( $item_id, $secondary_item_id, $total_items, $format, $id );


### PR DESCRIPTION
This PR includes:

* Fix - PHP Deprecated: Required parameter $component_action_name follows optional parameter $format in /var/www/html/wp-content/plugins/anspress/addons/buddypress/buddypress.php on line 431
* Fix - PHP Deprecated: Required parameter $component_name follows optional parameter $format in /var/www/html/wp-content/plugins/anspress/addons/buddypress/buddypress.php on line 431
* Fix - PHP Deprecated: Required parameter $id follows optional parameter $format in /var/www/html/wp-content/plugins/anspress/addons/buddypress/buddypress.php on line 431