### PR TITLE
[Fix] Uncaught TypeError: AnsPress.ajaxResponse is not a function

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -74,6 +74,9 @@ window.AnsPress = _.extend({
 
 		return jQuery.ajax(options);
 	},
+	ajaxResponse: function(data) {
+		return data;
+	},
 	uniqueId: function () {
 		return jQuery('.ap-uid').length;
 	},


### PR DESCRIPTION
This PR includes:

* Fix - Uncaught TypeError: AnsPress.ajaxResponse is not a function