### PR TITLE
[Fix] Empty border on the activities page if there are no user activities found

### DIFF
--- a/templates/activities/activities.php
+++ b/templates/activities/activities.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<div class="ap-activities">
+<div class="ap-activities<?php echo esc_attr( ! $activities->has() ? ' ap-no-activities' : '' ); ?>">
 	<?php if ( $activities->have() ) : ?>
 
 		<?php

--- a/templates/scss/activity.scss
+++ b/templates/scss/activity.scss
@@ -13,6 +13,13 @@
 			left: 20px;
 			top: 0;
 		}
+
+		&.ap-no-activities {
+
+			&::before {
+				display: none;
+			}
+		}
 	}
 	.ap-activity{
 		&-item:last-child{


### PR DESCRIPTION
This PR includes:

* Fixes the empty border display on the activities page if there are no user activities found