### PR TITLE
[Fix] Blank contents on AnsPress related pages if Block theme is used

### DIFF
--- a/includes/class-theme.php
+++ b/includes/class-theme.php
@@ -243,6 +243,10 @@ class AnsPress_Theme {
 		if ( is_anspress() ) {
 			$templates = array( 'anspress.php', 'page.php', 'singular.php', 'index.php' );
 
+			if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+				$templates = array();
+			}
+
 			if ( is_page() ) {
 				$_post = get_queried_object();
 


### PR DESCRIPTION
This PR includes:

* Fixes block based theme with empty **index.php** file does not display any AnsPress page contents on the front end when viewing the AnsPress related page