### PR TITLE
[Fix] Mark all as seen notification button click does not reset the notification counter number

### DIFF
--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -142,6 +142,16 @@
 				dpView.$el.hide();
 			}
 		});
+
+		// Clicking on Mark all as seen button removes/resets the notification numbers.
+		$( document ).on( 'click', '.ap-btn-markall-read', function() {
+			$( document ).ajaxSuccess( function() {
+				$( '.ap-btn-markall-read' ).remove();
+				$( '.ap-menu-notifications' ).find( 'span' ).remove();
+				$( '.ap-noti-unseen' ).remove();
+				$( '[href="#apNotifications"]' ).find( 'span' ).html( '0' );
+			} );
+		} );
 	});
 
 })(jQuery);


### PR DESCRIPTION
This PR includes:

* Fixes the **Mark all as seen** notification button click Ajax event to reset the notification counter number throughout the site