### PR TITLE
[Fix] Insert image button on Question and Answer form always available

### DIFF
--- a/lib/form/class-editor.php
+++ b/lib/form/class-editor.php
@@ -77,7 +77,9 @@ class Editor extends \AnsPress\Form\Field {
 			)
 		);
 
-		$this->add_html( '<button type="button" class="ap-btn-insertimage ap-btn-small ap-btn mb-10 ap-mr-5" apajaxbtn aponce="false" apquery="' . esc_js( $btn_args ) . '"><i class="apicon-image ap-mr-3"></i>' . __( 'Insert image', 'anspress-question-answer' ) . '</button>' );
+		if ( ap_user_can_upload() ) {
+			$this->add_html( '<button type="button" class="ap-btn-insertimage ap-btn-small ap-btn mb-10 ap-mr-5" apajaxbtn aponce="false" apquery="' . esc_js( $btn_args ) . '"><i class="apicon-image ap-mr-3"></i>' . __( 'Insert image', 'anspress-question-answer' ) . '</button>' );
+		}
 
 		/**
 		 * Action trigged after image button before editor.


### PR DESCRIPTION
This PR includes:

* Fixes the **Insert image** button on the question and answer editor to not get displayed if **Allow image upload** option is disabled