### PR TITLE
[Fix] Homepage questions pagination does not work directly if the home page is set to Your latest posts

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -99,7 +99,7 @@ class AnsPress_Hooks {
 			anspress()->add_filter( 'request', 'AnsPress_Rewrite', 'alter_the_query' );
 			anspress()->add_filter( 'query_vars', 'AnsPress_Rewrite', 'query_var' );
 			anspress()->add_action( 'generate_rewrite_rules', 'AnsPress_Rewrite', 'rewrites', 1 );
-			anspress()->add_filter( 'paginate_links', 'AnsPress_Rewrite', 'bp_com_paged' );
+			anspress()->add_filter( 'paginate_links', 'AnsPress_Rewrite', 'pagination_fix' );
 			anspress()->add_filter( 'parse_request', 'AnsPress_Rewrite', 'add_query_var' );
 			anspress()->add_action( 'template_redirect', 'AnsPress_Rewrite', 'shortlink' );
 

--- a/includes/rewrite.php
+++ b/includes/rewrite.php
@@ -172,12 +172,27 @@ class AnsPress_Rewrite {
 	}
 
 	/**
-	 * BuddyPress pagination fix.
+	 * Pagination fix.
 	 *
 	 * @param array $args Arguments.
 	 * @return array
 	 */
-	public static function bp_com_paged( $args ) {
+	public static function pagination_fix( $args ) {
+		/**
+		 * Home page pagination fix,
+		 * when the questions are directly used within the loop,
+		 * i.e., without setting the static front page.
+		 *
+		 * @param array $args Arguments.
+		 * @return array
+		 */
+		if ( is_front_page() && is_home() ) {
+			return preg_replace( '/page.([0-9]+).*/', '?page=$1', $args );
+		}
+
+		/**
+		 * BuddyPress pagination fix.
+		 */
 		if ( function_exists( 'bp_current_component' ) ) {
 			$bp_com = bp_current_component();
 


### PR DESCRIPTION
This PR includes:

* Fixes the questions lists pagination on homepage for **AskBug** theme when the **Your homepage displays** option is set to **Your latest posts**