### PR TITLE
[Fix] Marked as closed question activity always shown even when reverted back

### DIFF
--- a/includes/ajax-hooks.php
+++ b/includes/ajax-hooks.php
@@ -385,6 +385,13 @@ class AnsPress_Ajax {
 					'action' => 'closed_q',
 				)
 			);
+		} else {
+			ap_activity_add(
+				array(
+					'q_id'   => $_post->ID,
+					'action' => 'open_q',
+				)
+			);
 		}
 
 		$results = array(

--- a/includes/class/class-activity-helper.php
+++ b/includes/class/class-activity-helper.php
@@ -226,6 +226,11 @@ class Activity_Helper {
 				'verb'     => __( 'Marked as closed', 'anspress-question-answer' ),
 				'icon'     => 'apicon-alert',
 			),
+			'open_q'              => array(
+				'ref_type' => 'question',
+				'verb'     => __( 'Re-opened the question', 'anspress-question-answer' ),
+				'icon'     => 'apicon-question',
+			),
 			'new_c'               => array(
 				'ref_type' => 'comment',
 				'verb'     => __( 'Posted new comment', 'anspress-question-answer' ),


### PR DESCRIPTION
This PR includes:

* Fixes **Marked as closed** question activity still shown after the question content even after the question is re-opened