### PR TITLE
[Fix] Marked as featured question question activity always shown even when reverted back

### DIFF
--- a/includes/ajax-hooks.php
+++ b/includes/ajax-hooks.php
@@ -315,6 +315,15 @@ class AnsPress_Ajax {
 		// Check if current question ID is in featured question array.
 		if ( ap_is_featured_question( $post ) ) {
 			ap_unset_featured_question( $post->ID );
+
+			// Update activity.
+			ap_activity_add(
+				array(
+					'q_id'   => $post->ID,
+					'action' => 'unfeatured',
+				)
+			);
+
 			ap_ajax_json(
 				array(
 					'success'  => true,

--- a/includes/class/class-activity-helper.php
+++ b/includes/class/class-activity-helper.php
@@ -221,6 +221,11 @@ class Activity_Helper {
 				'verb'     => __( 'Marked as featured question', 'anspress-question-answer' ),
 				'icon'     => 'apicon-star',
 			),
+			'unfeatured'          => array(
+				'ref_type' => 'question',
+				'verb'     => __( 'Unfeatured the question', 'anspress-question-answer' ),
+				'icon'     => 'apicon-question',
+			),
 			'closed_q'            => array(
 				'ref_type' => 'question',
 				'verb'     => __( 'Marked as closed', 'anspress-question-answer' ),


### PR DESCRIPTION
This PR includes:

* Fixes **Marked as featured question** question activity still shown after the question content even after the question is unfeatured