### PR TITLE
[Fix] Questions page is not possible to be set as Static Home page

### DIFF
--- a/admin/anspress-admin.php
+++ b/admin/anspress-admin.php
@@ -604,7 +604,7 @@ class AnsPress_Admin {
 	 * @return array
 	 */
 	public static function get_pages( $pages, $r ) {
-		if ( isset( $r['name'] ) && 'page_on_front' === $r['name'] ) {
+		if ( ! ap_opt( 'base_page_static_front_page' ) && isset( $r['name'] ) && ( 'page_on_front' === $r['name'] || '_customize-dropdown-pages-page_on_front' === $r['name'] ) ) {
 			foreach ( (array) $pages as $k => $page ) {
 				if ( ap_opt( 'base_page' ) == $page->ID ) { // phpcs:disable Universal.Operators.StrictComparisons.LooseEqual
 					unset( $pages[ $k ] );
@@ -921,6 +921,13 @@ class AnsPress_Admin {
 					'desc'  => __( 'Check this to load AnsPress JS and CSS on the AnsPress page only. Be careful, this might break layout.', 'anspress-question-answer' ),
 					'type'  => 'checkbox',
 					'value' => $opt['load_assets_in_anspress_only'],
+				),
+				'base_page_static_front_page'  => array(
+					'name'  => '',
+					'label' => __( 'Static Front Page', 'anspress-question-answer' ),
+					'desc'  => __( 'Check this option to enable the base page, .i.e. Question\'s page to be set as a Static front page for your site.', 'anspress-question-answer' ),
+					'type'  => 'checkbox',
+					'value' => $opt['base_page_static_front_page'],
 				),
 				'avatar_size_list'             => array(
 					'label'   => __( 'List avatar size', 'anspress-question-answer' ),

--- a/includes/options.php
+++ b/includes/options.php
@@ -126,6 +126,7 @@ function ap_default_options() {
 		'disable_down_vote_on_answer'   => false,
 		'show_solved_prefix'            => true,
 		'load_assets_in_anspress_only'  => false,
+		'base_page_static_front_page'   => false,
 		'keep_stop_words'               => true,
 		'default_date_format'           => false,
 		'anonymous_post_status'         => 'moderate',


### PR DESCRIPTION
This PR includes:

* Added option to enable the Questions page(Base page) to be set as a static front page