### PR TITLE
[Fix] PHP Warning: Attempt to read property "comment_ID" on int

### DIFF
--- a/addons/buddypress/buddypress.php
+++ b/addons/buddypress/buddypress.php
@@ -587,7 +587,7 @@ class BuddyPress extends \AnsPress\Singleton {
 			return;
 		}
 
-		if ( $comment->comment_ID ) {
+		if ( isset( $comment->comment_ID ) && $comment->comment_ID ) {
 			bp_notifications_delete_all_notifications_by_type( $comment->comment_ID, 'anspress', 'new_comment' );
 		} else {
 			$comments = get_comments( array( 'post_id' => $comment ) );


### PR DESCRIPTION
This PR includes:

* Fixes PHP Warning: Attempt to read property comment_ID on int when deleting question, answer, or comment from the front end if **BuddyPress** plugin and **BuddyPress** feature/addon is active