### PR TITLE
 [Fix] Reputation events icon not displayed on the users' reputation page

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -77,8 +77,8 @@ class AP_Activate {
 		// Append table names in $wpdb.
 		ap_append_table_names();
 
-		// Set the reputation events icon.
-		$this->set_reputation_events_icon();
+		// Migrate old datas.
+		$this->migrate();
 
 		if ( $this->network_wide ) {
 			$this->network_activate();
@@ -406,6 +406,21 @@ class AP_Activate {
 
 				ap_activate_addon( $new_addon_name );
 			}
+		}
+	}
+
+	/**
+	 * Migrate old datas.
+	 *
+	 * @since 4.4.0
+	 */
+	public function migrate() {
+
+		// Migrate old datas according to the AP_DB_VERSION constant.
+		switch ( AP_DB_VERSION ) {
+			case 38:
+				$this->set_reputation_events_icon();
+				break;
 		}
 	}
 

--- a/activate.php
+++ b/activate.php
@@ -415,12 +415,8 @@ class AP_Activate {
 	 * @since 4.4.0
 	 */
 	public function migrate() {
-
-		// Migrate old datas according to the AP_DB_VERSION constant.
-		switch ( AP_DB_VERSION ) {
-			case 38:
-				$this->set_reputation_events_icon();
-				break;
+		if ( 38 === AP_DB_VERSION ) {
+			$this->set_reputation_events_icon();
 		}
 	}
 

--- a/activate.php
+++ b/activate.php
@@ -77,6 +77,9 @@ class AP_Activate {
 		// Append table names in $wpdb.
 		ap_append_table_names();
 
+		// Set the reputation events icon.
+		$this->set_reputation_events_icon();
+
 		if ( $this->network_wide ) {
 			$this->network_activate();
 		} else {
@@ -403,6 +406,36 @@ class AP_Activate {
 
 				ap_activate_addon( $new_addon_name );
 			}
+		}
+	}
+
+	/**
+	 * Set the reputation events icon.
+	 *
+	 * @since 4.4.0
+	 */
+	public function set_reputation_events_icon() {
+		$events = array(
+			'register'           => 'apicon-question',
+			'ask'                => 'apicon-question',
+			'answer'             => 'apicon-answer',
+			'comment'            => 'apicon-comments',
+			'select_answer'      => 'apicon-check',
+			'best_answer'        => 'apicon-check',
+			'received_vote_up'   => 'apicon-thumb-up',
+			'received_vote_down' => 'apicon-thumb-down',
+			'given_vote_up'      => 'apicon-thumb-up',
+			'given_vote_down'    => 'apicon-thumb-down',
+		);
+
+		// Modify reputation events icon.
+		global $wpdb;
+		foreach ( $events as $slug => $icon ) {
+			$wpdb->update( // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prefix . 'ap_reputation_events',
+				array( 'icon' => $icon ),
+				array( 'slug' => $slug )
+			);
 		}
 	}
 }

--- a/addons/reputation/reputation.php
+++ b/addons/reputation/reputation.php
@@ -77,7 +77,6 @@ class Reputation extends \AnsPress\Singleton {
 		anspress()->add_filter( 'ap_bp_nav', $this, 'ap_bp_nav' );
 		anspress()->add_filter( 'ap_bp_page', $this, 'ap_bp_page', 10, 2 );
 		anspress()->add_filter( 'ap_all_options', $this, 'ap_all_options', 10, 2 );
-		anspress()->add_action( 'init', $this, 'ap_truncate_reputation_events_table' );
 	}
 
 	/**
@@ -598,31 +597,6 @@ class Reputation extends \AnsPress\Singleton {
 		);
 
 		return $all_options;
-	}
-
-	/**
-	 * Delete ap_reputation_events table datas,
-	 * since there is no icon set in the database for the reputation event,
-	 * and editing the table directly is not possible.
-	 */
-	public function ap_truncate_reputation_events_table() {
-		// Return if ap_reputation_events_contents_deleted exists.
-		if ( get_option( 'ap_reputation_events_contents_deleted' ) ) {
-			return;
-		}
-
-		global $wpdb;
-		// Delete the table contents of $wpdb->ap_reputation_events table.
-		$reputation_events_table = $wpdb->ap_reputation_events;
-		if ( $reputation_events_table ) {
-			$wpdb->query( "TRUNCATE TABLE {$reputation_events_table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		}
-
-		// Update/Set the reputation default events in the database table.
-		$this->register_default_events();
-
-		// Update option.
-		update_option( 'ap_reputation_events_contents_deleted', true );
 	}
 }
 

--- a/anspress-question-answer.php
+++ b/anspress-question-answer.php
@@ -33,7 +33,7 @@ if ( ! defined( 'WPINC' ) ) {
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed
 
 // Define database version.
-define( 'AP_DB_VERSION', 37 );
+define( 'AP_DB_VERSION', 38 );
 
 // Check if using required PHP version.
 if ( version_compare( PHP_VERSION, '7.2' ) < 0 ) {

--- a/includes/reputation.php
+++ b/includes/reputation.php
@@ -340,6 +340,7 @@ function ap_get_users_reputation( $user_ids ) {
  *
  * @return int|WP_Error Return insert event id on success and WP_Error on failure.
  * @since 4.3.0
+ * @since 4.4.0 Added new argument `$icon` for setting the respective reputation event icon.
  */
 function ap_insert_reputation_event( $slug, $label, $description, $points, $activity, $parent_type = '', $icon = '' ) {
 	global $wpdb;

--- a/includes/reputation.php
+++ b/includes/reputation.php
@@ -335,12 +335,13 @@ function ap_get_users_reputation( $user_ids ) {
  * @param string $description Reputation event description.
  * @param int    $points      Signed point value.
  * @param int    $activity    Activity label.
- * @param string $parent_type      Parent type.
+ * @param string $parent_type Parent type.
+ * @param string $icon        Reputation event icon.
  *
  * @return int|WP_Error Return insert event id on success and WP_Error on failure.
  * @since 4.3.0
  */
-function ap_insert_reputation_event( $slug, $label, $description, $points, $activity, $parent_type = '' ) {
+function ap_insert_reputation_event( $slug, $label, $description, $points, $activity, $parent_type = '', $icon = '' ) {
 	global $wpdb;
 
 	$slug     = sanitize_key( $slug );
@@ -359,12 +360,14 @@ function ap_insert_reputation_event( $slug, $label, $description, $points, $acti
 			'points'      => $points,
 			'activity'    => $activity,
 			'parent'      => $parent_type,
+			'icon'        => $icon,
 		),
 		array(
 			'%s',
 			'%s',
 			'%s',
 			'%d',
+			'%s',
 			'%s',
 			'%s',
 		)


### PR DESCRIPTION
This PR includes:

* Fixes the reputation events icon not being displayed inside the circular area on the users' reputation page