### PR TITLE
[Fix] Trashed Question Available On The New Answer Page

### DIFF
--- a/admin/views/select_question.php
+++ b/admin/views/select_question.php
@@ -32,7 +32,8 @@ if ( ! defined( 'WPINC' ) ) {
 			<?php
 				$questions = new Question_Query(
 					array(
-						'post_status' => array( 'publish', 'private_post' ),
+						'post_status'         => array( 'publish', 'private_post' ),
+						'post_status__not_in' => array( 'trash' ),
 					)
 				);
 				?>

--- a/includes/qaquery.php
+++ b/includes/qaquery.php
@@ -87,9 +87,18 @@ class Question_Query extends WP_Query {
 			if ( is_super_admin() ) {
 				$this->args['post_status'][] = 'trash';
 			}
-
-			$this->args['post_status'] = array_unique( $this->args['post_status'] );
 		}
+
+		// Post status to ignore if passed via args.
+		if ( isset( $this->args['post_status__not_in'] ) ) {
+			$post_status__not_in = $this->args['post_status__not_in'];
+
+			// Update the post_status args.
+			$this->args['post_status'] = array_diff( $this->args['post_status'], $post_status__not_in );
+		}
+
+		// Updated post_status args to have the unique array.
+		$this->args['post_status'] = array_unique( $this->args['post_status'] );
 
 		// Show only the unpublished post of author.
 		if ( isset( $args['ap_show_unpublished'] ) && true === $this->args['ap_show_unpublished'] ) {


### PR DESCRIPTION
This PR includes:

* Fixes the trashed question to not appear on the **Recently active questions** section under the **New Answer** page