### PR TITLE
[Fix] Categories page the category icon is not placed exactly in the center 

### DIFF
--- a/templates/scss/category.scss
+++ b/templates/scss/category.scss
@@ -32,10 +32,12 @@
     position: relative;
     .ap-category-icon {
       left: 50%;
-      margin-left: -20px;
-      margin-top: -20px;
       position: absolute;
       top: 50%;
+      transform: translate(-50%, -50%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
   }
   .ap-term-count {


### PR DESCRIPTION
This PR includes:

* Fixes the category icon to be placed exactly in the center of the div on the categories page