### PR TITLE
[Fix] When deleting a question, only the answers with publish status will get deleted

### DIFF
--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -238,7 +238,7 @@ class AnsPress_Hooks {
 			 */
 			do_action( 'ap_before_delete_question', $post->ID, $post );
 
-			$answers = get_posts( [ 'post_parent' => $post->ID, 'post_type' => 'answer' ] ); // @codingStandardsIgnoreLine
+			$answers = get_posts( [ 'post_parent' => $post->ID, 'post_type' => 'answer', 'post_status' => get_post_stati() ] ); // @codingStandardsIgnoreLine
 
 			foreach ( (array) $answers as $a ) {
 				self::delete_answer( $a->ID, $a );


### PR DESCRIPTION
This PR includes:

* Fixes the answer not deleted automatically with question permanently delete if its post status is other than the publish