### PR TITLE
[Fix] PHP warning message when viewing the invalid comment via popup

### DIFF
--- a/includes/comments.php
+++ b/includes/comments.php
@@ -53,13 +53,17 @@ class AnsPress_Comment_Hooks {
 
 		if ( ! empty( $comment_id ) ) {
 			$_comment = get_comment( $comment_id );
-			$post_id  = $_comment->comment_post_ID;
+			if ( isset( $_comment->comment_post_ID ) && $_comment->comment_post_ID ) {
+				$post_id = $_comment->comment_post_ID;
+			}
 		} else {
 			$post_id = ap_sanitize_unslash( 'post_id', 'r' );
 			$paged   = max( 1, ap_isset_post_value( 'paged', 1 ) );
 		}
 
-		$_post = ap_get_post( $post_id );
+		if ( isset( $post_id ) && $post_id ) {
+			$_post = ap_get_post( $post_id );
+		}
 
 		$args = array(
 			'show_more' => false,
@@ -71,10 +75,16 @@ class AnsPress_Comment_Hooks {
 		}
 
 		ob_start();
-		ap_the_comments( $post_id, $args );
+		if ( isset( $post_id ) && $post_id ) {
+			ap_the_comments( $post_id, $args );
+		} else {
+			ap_the_comments( -1, $args );
+		}
 		$html = ob_get_clean();
 
-		$type = 'question' === $_post->post_type ? __( 'Question', 'anspress-question-answer' ) : __( 'Answer', 'anspress-question-answer' );
+		if ( isset( $_post ) && $_post->post_type ) {
+			$type = 'question' === $_post->post_type ? __( 'Question', 'anspress-question-answer' ) : __( 'Answer', 'anspress-question-answer' );
+		}
 
 		$result = array(
 			'success' => true,


### PR DESCRIPTION
This PR includes:

* Fixes PHP Warning:  Attempt to read property "comment_post_ID" on null in /var/www/html/wp-content/plugins/anspress/includes/comments.php on line 56
* Fixes PHP Warning:  Attempt to read property "post_type" on bool in /var/www/html/wp-content/plugins/anspress/includes/comments.php on line 77