### PR TITLE
[Fix] Answer editor does not close by itself after answering the question if Quick Tags editor is enabled

### DIFF
--- a/assets/js/question.js
+++ b/assets/js/question.js
@@ -378,7 +378,9 @@
 			if (data.success && data.form === 'answer') {
 				AnsPress.trigger('answerFormPosted', data);
 				$('apanswersw').show();
-				tinymce.remove();
+				if ( typeof tinymce !== 'undefined' ) {
+					tinymce.remove();
+				}
 
 				// Clear editor contents
 				$('#ap-form-main').html('');

--- a/assets/js/question.js
+++ b/assets/js/question.js
@@ -365,7 +365,6 @@
 			AnsPress.ajax({
 				data: $(e.target).data('apquery'),
 				success: function (data) {
-					console.log(data)
 					AnsPress.hideLoading(e.target);
 					$('#ap-form-main').html(data);
 					$(e.target).closest('.ap-minimal-editor').removeClass('ap-minimal-editor');


### PR DESCRIPTION
This PR includes:

* Fix the answer editor does not close by itself after answering the question if Quick Tags editor is enabled
* Remove unrequired **console.log** for rendering the form field when clicking on the answer editor